### PR TITLE
Bug fix: refcheck now dies if spaces in sequence names

### DIFF
--- a/ariba/refcheck.py
+++ b/ariba/refcheck.py
@@ -5,78 +5,86 @@ class Error (Exception): pass
 
 
 class Checker:
-    def __init__(self, infile, min_length=1, max_length=10000):
+    def __init__(self, infile, min_length=1, max_length=10000, outprefix=None):
         self.infile = os.path.abspath(infile)
         if not os.path.exists(self.infile):
             raise Error('File not found: "' + self.infile + '". Cannot continue')
 
         self.min_length = min_length
         self.max_length = max_length
+        self.outprefix = outprefix
 
 
-    def check(self, error_code_on_exit=None):
+    def run(self):
         file_reader = pyfastaq.sequences.file_reader(self.infile)
-
-        for seq in file_reader:
-            if not seq.looks_like_gene():
-                return False, 'Not a gene', seq
-            elif len(seq) < self.min_length:
-                return False, 'Too short', seq
-            elif len(seq) > self.max_length:
-                return False, 'Too long', seq
-           
-        return True, None, None
-
-
-    def fix(self, outprefix):
-        file_reader = pyfastaq.sequences.file_reader(self.infile)
-        old2new_out = outprefix + '.rename'
-        fasta_out = outprefix + '.fa'
-        bad_seqs_out = outprefix + '.removed.fa'
-        log_out = outprefix + '.log'
         names = {}
-        old2new_out_fh = pyfastaq.utils.open_file_write(old2new_out)
-        fasta_out_fh = pyfastaq.utils.open_file_write(fasta_out)
-        bad_seqs_out_fh = pyfastaq.utils.open_file_write(bad_seqs_out)
-        log_out_fh = pyfastaq.utils.open_file_write(log_out)
+
+        if self.outprefix is not None:
+            old2new_out = self.outprefix + '.rename'
+            fasta_out = self.outprefix + '.fa'
+            bad_seqs_out = self.outprefix + '.removed.fa'
+            log_out = self.outprefix + '.log'
+            old2new_out_fh = pyfastaq.utils.open_file_write(old2new_out)
+            fasta_out_fh = pyfastaq.utils.open_file_write(fasta_out)
+            bad_seqs_out_fh = pyfastaq.utils.open_file_write(bad_seqs_out)
+            log_out_fh = pyfastaq.utils.open_file_write(log_out)
 
         for seq in file_reader:
             seq.seq = seq.seq.upper()
             if len(seq) < self.min_length:
-                print(seq.id, 'Too short. Skipping', sep='\t', file=log_out_fh)
-                print(seq, file=bad_seqs_out_fh)
-                continue
-            elif len(seq) > self.max_length:
-                print(seq.id, 'Too long. Skipping', sep='\t', file=log_out_fh)
-                print(seq, file=bad_seqs_out_fh)
-                continue
-
-
-            if not seq.looks_like_gene():
-                seq.revcomp()
-                if seq.looks_like_gene():
-                    print(seq.id, 'Reverse complemented', sep='\t', file=log_out_fh)
+                if self.outprefix is None:
+                    return False, 'Too short', seq
                 else:
-                    print(seq.id, 'Does not look like a gene. Skipping', sep='\t', file=log_out_fh)
-                    seq.revcomp()
+                    print(seq.id, 'Too short. Skipping', sep='\t', file=log_out_fh)
                     print(seq, file=bad_seqs_out_fh)
                     continue
-                
+            elif len(seq) > self.max_length:
+                if self.outprefix is None:
+                    return False, 'Too long', seq
+                else:
+                    print(seq.id, 'Too long. Skipping', sep='\t', file=log_out_fh)
+                    print(seq, file=bad_seqs_out_fh)
+                    continue
+
+            if not seq.looks_like_gene():
+                if self.outprefix is None:
+                    return False, 'Not a gene', seq
+                else:
+                    seq.revcomp()
+                    if seq.looks_like_gene():
+                        print(seq.id, 'Reverse complemented', sep='\t', file=log_out_fh)
+                    else:
+                        print(seq.id, 'Does not look like a gene. Skipping', sep='\t', file=log_out_fh)
+                        seq.revcomp()
+                        print(seq, file=bad_seqs_out_fh)
+                        continue
+
             original_id = seq.id
             # replace unwanted characters with underscores
             to_replace = ' '
             seq.id = seq.id.translate(str.maketrans(to_replace, '_' *  len(to_replace)))
 
+            if self.outprefix is None and original_id != seq.id:
+                seq.id = original_id
+                return False, 'Name has spaces', seq
+
             if seq.id in names:
-                names[seq.id] += 1
-                seq.id += '.' + str(names[seq.id])
+                if self.outprefix is None:
+                    return False, 'Duplicate name', seq
+                else:
+                    names[seq.id] += 1
+                    seq.id += '.' + str(names[seq.id])
             else:
                 names[seq.id] = 1
 
-            print(original_id, seq.id, sep='\t', file=old2new_out_fh)
-            print(seq, file=fasta_out_fh)
+            if self.outprefix is not None:
+                print(original_id, seq.id, sep='\t', file=old2new_out_fh)
+                print(seq, file=fasta_out_fh)
 
-        pyfastaq.utils.close(fasta_out_fh)
-        pyfastaq.utils.close(bad_seqs_out_fh)
-        pyfastaq.utils.close(log_out_fh)
-        pyfastaq.utils.close(old2new_out_fh)
+        if self.outprefix is not None:
+            pyfastaq.utils.close(fasta_out_fh)
+            pyfastaq.utils.close(bad_seqs_out_fh)
+            pyfastaq.utils.close(log_out_fh)
+            pyfastaq.utils.close(old2new_out_fh)
+
+        return True, None, None

--- a/ariba/tasks/refcheck.py
+++ b/ariba/tasks/refcheck.py
@@ -18,14 +18,14 @@ def run():
     checker = ariba.refcheck.Checker(
         options.infile,
         min_length=options.min_length,
-        max_length=options.max_length
+        max_length=options.max_length,
+        outprefix=options.outprefix
     )
- 
-    if options.outprefix:
-        checker.fix(options.outprefix)
-    else:
-        ok, reason, seq = checker.check()
-        if not ok:
-            print('The following sequence not OK, for the reason:', reason)
-            print(seq)
-            sys.exit(1)
+
+    ok, reason, seq = checker.run()
+
+    if options.outprefix is None and not ok:
+        print('The following sequence not OK, for the reason:', reason)
+        print(seq)
+        sys.exit(1)
+

--- a/ariba/tests/data/refcheck_test_check_duplicate_name.fa
+++ b/ariba/tests/data/refcheck_test_check_duplicate_name.fa
@@ -1,0 +1,4 @@
+>gene1
+TTGTGGTGA
+>gene1
+TTGTGGTGA

--- a/ariba/tests/data/refcheck_test_check_spaces_in_name.fa
+++ b/ariba/tests/data/refcheck_test_check_spaces_in_name.fa
@@ -1,0 +1,2 @@
+>gene foo
+TTGTGGTGA

--- a/ariba/tests/refcheck_test.py
+++ b/ariba/tests/refcheck_test.py
@@ -13,7 +13,7 @@ class TestRefcheck(unittest.TestCase):
         '''test check file OK'''
         infile = os.path.join(data_dir, 'refcheck_test_check_ok.fa')
         c = refcheck.Checker(infile)
-        self.assertEqual(c.check(), (True, None, None))
+        self.assertEqual(c.run(), (True, None, None))
 
 
     def test_check_file_fail_not_gene(self):
@@ -21,7 +21,7 @@ class TestRefcheck(unittest.TestCase):
         infile = os.path.join(data_dir, 'refcheck_test_check_not_gene.fa')
         c = refcheck.Checker(infile)
         seq = pyfastaq.sequences.Fasta('gene1', 'TTGTGATGA')
-        self.assertEqual(c.check(), (False, 'Not a gene', seq))
+        self.assertEqual(c.run(), (False, 'Not a gene', seq))
 
 
     def test_check_file_fail_too_short(self):
@@ -29,7 +29,7 @@ class TestRefcheck(unittest.TestCase):
         infile = os.path.join(data_dir, 'refcheck_test_check_too_short.fa')
         c = refcheck.Checker(infile, min_length=10)
         seq = pyfastaq.sequences.Fasta('gene1', 'TTGTGGTGA')
-        self.assertEqual(c.check(), (False, 'Too short', seq))
+        self.assertEqual(c.run(), (False, 'Too short', seq))
 
 
     def test_check_file_fail_too_long(self):
@@ -37,15 +37,31 @@ class TestRefcheck(unittest.TestCase):
         infile = os.path.join(data_dir, 'refcheck_test_check_too_long.fa')
         c = refcheck.Checker(infile, max_length=6)
         seq = pyfastaq.sequences.Fasta('gene1', 'TTGTGGTGA')
-        self.assertEqual(c.check(), (False, 'Too long', seq))
+        self.assertEqual(c.run(), (False, 'Too long', seq))
 
 
-    def test_check_fix(self):
-        '''test fix'''
+    def test_check_file_fail_spades_in_name(self):
+        '''test check file with sequence that has spaces in its name'''
+        infile = os.path.join(data_dir, 'refcheck_test_check_spaces_in_name.fa')
+        c = refcheck.Checker(infile, min_length=3)
+        seq = pyfastaq.sequences.Fasta('gene foo', 'TTGTGGTGA')
+        self.assertEqual(c.run(), (False, 'Name has spaces', seq))
+
+
+    def test_check_file_fail_duplicate_name(self):
+        '''test check file with sequence that has two genes with the same name'''
+        infile = os.path.join(data_dir, 'refcheck_test_check_duplicate_name.fa')
+        c = refcheck.Checker(infile, min_length=3)
+        seq = pyfastaq.sequences.Fasta('gene1', 'TTGTGGTGA')
+        self.assertEqual(c.run(), (False, 'Duplicate name', seq))
+
+
+    def test_check_run_with_outfiles(self):
+        '''test run when making output files'''
         infile = os.path.join(data_dir, 'refcheck_test_fix_in.fa')
         tmp_prefix = 'tmp.refcheck_test_fix.out'
-        c = refcheck.Checker(infile, min_length=10, max_length=25)
-        c.fix(tmp_prefix)
+        c = refcheck.Checker(infile, min_length=10, max_length=25, outprefix=tmp_prefix)
+        c.run()
         for x in ['fa', 'log', 'rename', 'removed.fa']:
             expected = os.path.join(data_dir, 'refcheck_test_fix_out.' + x)
             got = tmp_prefix + '.' + x


### PR DESCRIPTION
When checking if an input sequence was OK, it should have stopped on the first encounter with a sequence that has a space in its name. Instead it carried on. Behaviour was OK when fixing the input sequence, to make a new FASTA file. The PR fixes that bug.