### PR TITLE
Improvements to summary output; new flag for non-synonymous variants

### DIFF
--- a/ariba/common.py
+++ b/ariba/common.py
@@ -1,7 +1,7 @@
 import sys
 import subprocess
 
-version = '0.5.0'
+version = '0.6.0'
 
 def syscall(cmd, allow_fail=False, verbose=False):
     if verbose:

--- a/ariba/flag.py
+++ b/ariba/flag.py
@@ -11,6 +11,7 @@ flags_in_order = [
     'assembly_fail',
     'variants_suggest_collapsed_repeat',
     'hit_both_strands',
+    'has_nonsynonymous_variants',
 ]
 
 

--- a/ariba/summary.py
+++ b/ariba/summary.py
@@ -122,10 +122,13 @@ class Summary:
         if f.has('hit_both_strands') or (not f.has('complete_orf')):
             return 1
 
-        if f.has('unique_contig') and f.has('gene_assembled_into_one_contig'):
-            return 3
-
-        return 2
+        if f.has('unique_contig') and f.has('gene_assembled_into_one_contig') and f.has('complete_orf'):
+            if f.has('has_nonsynonymous_variants'):
+                return 3
+            else:
+                return 4
+        else:
+            return 2
 
 
     def _pc_id_of_longest(self, l):

--- a/ariba/summary.py
+++ b/ariba/summary.py
@@ -48,6 +48,7 @@ class Summary:
       outfile,
       filenames=None,
       fofn=None,
+      filter_output=True,
       min_id=90.0
     ):
         if filenames is None and fofn is None:
@@ -61,6 +62,7 @@ class Summary:
         if fofn is not None:
             self.filenames.extend(self._load_fofn(fofn))
 
+        self.filter_output = filter_output
         self.min_id = min_id
         self.outfile = outfile
 
@@ -168,6 +170,9 @@ class Summary:
 
 
     def _filter_output_rows(self):
+        if not self.filter_output:
+            return
+
         # remove rows that are all zeros
         self.rows_out = [x for x in self.rows_out if x[1:] != [0]*(len(x)-1)]
 

--- a/ariba/tasks/summary.py
+++ b/ariba/tasks/summary.py
@@ -8,6 +8,7 @@ def run():
         epilog = 'Files must be listed after the output file and/or the option --fofn must be used. If both used, all files in the filename specified by --fofn AND the files listed after the output file will be used as input. The input report files must be in tsv format, not xls.')
     parser.add_argument('-f', '--fofn', help='File of filenames of ariba reports in tsv format (not xls) to be summarised. Must be used if no input files listed after the outfile.', metavar='FILENAME')
     parser.add_argument('--min_id', type=float, help='Minimum percent identity cutoff to count as assembled [%(default)s]', default=90, metavar='FLOAT')
+    parser.add_argument('--no_filter', action='store_true', help='Do not filter rows or columns of output that are all 0 (by deafult, they are removed from the output)')
     parser.add_argument('outfile', help='Name of output file. If file ends with ".xls", then an excel spreadsheet is written. Otherwise a tsv file is written')
     parser.add_argument('infiles', nargs='*', help='Files to be summarised')
     options = parser.parse_args()
@@ -18,6 +19,7 @@ def run():
         options.outfile,
         fofn=options.fofn,
         filenames=options.infiles,
+        filter_output=(not options.no_filter),
         min_id=options.min_id
     )
     s.run()

--- a/ariba/tests/cluster_test.py
+++ b/ariba/tests/cluster_test.py
@@ -730,7 +730,50 @@ class TestCluster(unittest.TestCase):
         clean_cluster_dir(cluster_dir)
 
 
-    def test_make_report_lines(self):
+    def test_make_report_lines_nonsynonymous(self):
+        '''test _make_report_lines'''
+        cluster_dir = os.path.join(data_dir, 'cluster_test_generic')
+        clean_cluster_dir(cluster_dir)
+        c = cluster.Cluster(cluster_dir, 'cluster_name')
+        c.gene = pyfastaq.sequences.Fasta('gene', 'GATCGCGAAGCGATGACCCATGAAGCGACCGAACGCTGA')
+        v1 = pymummer.variant.Variant(pymummer.snp.Snp('8\tA\tG\t8\tx\tx\t39\t39\tx\tx\tgene\tcontig'))
+
+        nucmer_hit = ['1', '10', '1', '10', '10', '10', '90.00', '1000', '1000', '1', '1', 'gene', 'contig']
+        c.nucmer_hits = {'contig': [pymummer.alignment.Alignment('\t'.join(nucmer_hit))]}
+        c.mummer_variants = {'contig': [[v1]]}
+        c.percent_identities = {'contig': 92.42}
+        c.status_flag.set_flag(42)
+        c.assembled_ok = True
+        c.final_assembly_read_depths = os.path.join(data_dir, 'cluster_test_make_report_lines.read_depths.gz')
+        c._make_report_lines()
+        expected = [[
+            'gene',
+            554,
+            2,
+            'cluster_name',
+            39,
+            10,
+            92.42,
+            'SNP',
+            'NONSYN',
+            'E3G',
+            8,
+            8,
+            'A',
+            'contig',
+            39,
+            8,
+            8,
+            'G',
+            '.',
+            '.',
+            '.'
+        ]]
+        self.assertEqual(expected, c.report_lines)
+        clean_cluster_dir(cluster_dir)
+
+
+    def test_make_report_lines_synonymous(self):
         '''test _make_report_lines'''
         cluster_dir = os.path.join(data_dir, 'cluster_test_generic')
         clean_cluster_dir(cluster_dir)

--- a/ariba/tests/flag_test.py
+++ b/ariba/tests/flag_test.py
@@ -24,7 +24,7 @@ class TestFlag(unittest.TestCase):
     def test_add(self):
         '''Test add'''
         f = flag.Flag()
-        expected = [1, 3, 7, 15, 31, 63, 127, 255, 511]
+        expected = [1, 3, 7, 15, 31, 63, 127, 255, 511, 1023]
         for i in range(len(flag.flags_in_order)):
             f.add(flag.flags_in_order[i])
             self.assertEqual(f.to_number(), expected[i])
@@ -50,6 +50,7 @@ class TestFlag(unittest.TestCase):
             '[ ] assembly_fail',
             '[ ] variants_suggest_collapsed_repeat',
             '[ ] hit_both_strands',
+            '[ ] has_nonsynonymous_variants',
         ])
 
         self.assertEqual(expected, f.to_long_string())

--- a/ariba/tests/summary_test.py
+++ b/ariba/tests/summary_test.py
@@ -75,7 +75,8 @@ class TestSummry(unittest.TestCase):
             (7, 1),
             (259, 1),
             (15, 2),
-            (27, 3),
+            (539, 3),
+            (27, 4),
         ]
 
         for t in tests:
@@ -96,8 +97,8 @@ class TestSummry(unittest.TestCase):
         s._gather_output_rows()
         expected = [
             ['filename', 'gene1', 'gene2', 'gene3'],
-            [infiles[0], 3, 2, 0],
-            [infiles[1], 3, 0, 3],
+            [infiles[0], 4, 2, 0],
+            [infiles[1], 4, 0, 4],
         ]
         self.assertEqual(expected, s.rows_out)
 

--- a/ariba/tests/summary_test.py
+++ b/ariba/tests/summary_test.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 import filecmp
 import os
 from ariba import summary, flag
@@ -103,7 +104,7 @@ class TestSummry(unittest.TestCase):
         self.assertEqual(expected, s.rows_out)
 
 
-    def test_filter_output_rows(self):
+    def test_filter_output_rows_filter_true(self):
         '''Test _filter_output_rows'''
         s = summary.Summary('out', filenames=['spam', 'eggs'])
         s.rows_out = [
@@ -121,6 +122,22 @@ class TestSummry(unittest.TestCase):
 
         s._filter_output_rows()
         self.assertEqual(s.rows_out, expected)
+
+
+    def test_filter_output_rows_filter_false(self):
+        '''Test _filter_output_rows'''
+        s = summary.Summary('out', filenames=['spam', 'eggs'], filter_output=False)
+        rows_out = [
+            ['filename', 'gene1', 'gene2', 'gene3'],
+            ['file1', 0, 0, 0],
+            ['file2', 1, 0, 3],
+            ['file3', 2, 0, 4],
+        ]
+
+        s.rows_out = copy.copy(rows_out)
+
+        s._filter_output_rows()
+        self.assertEqual(s.rows_out, rows_out)
 
 
     def test_write_tsv(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ariba',
-    version='0.5.0',
+    version='0.6.0',
     description='ARIBA: Antibiotic Resistance Identification By Assembly',
     packages = find_packages(),
     author='Martin Hunt',
@@ -18,9 +18,9 @@ setup(
     tests_require=['nose >= 1.3'],
     install_requires=[
         'openpyxl',
-        'pyfastaq >= 3.0.1',
+        'pyfastaq >= 3.10.0',
         'pysam >= 0.8.1',
-        'pymummer>=0.0.2'
+        'pymummer>=0.6.1'
     ],
     license='GPLv3',
     classifiers=[


### PR DESCRIPTION
* New flag 'has_nonsynonymous_variants', so user can easily tell if variants are really change or not
* Extra summary number in summary output, to disinguish between genes that have non-synonymous variants and those that do not
* Option to have summary output all information instead of default, which removes rows or columns where all values are zero (ie gene not there)
* Update dependency versions (which removes numpy as a dependency), and ariba version