### PR TITLE
Implement multithreading

### DIFF
--- a/ariba/cluster.py
+++ b/ariba/cluster.py
@@ -201,8 +201,8 @@ class Cluster:
                 best_score = score
                 best_gene_name = seq.id
 
-        print('Best gene is', best_gene_name, 'with total alignment score of', best_score, file=self.log_fh)
-        print()
+        print('\nBest gene is', best_gene_name, 'with total alignment score of', best_score, file=self.log_fh)
+        print(file=self.log_fh)
 
         return best_gene_name
 

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -13,10 +13,10 @@ class Error (Exception): pass
 
 def _run_cluster(obj, verbose):
     if verbose:
-        print('Start running cluster', obj.name, 'in directory', obj.root_dir)
+        print('Start running cluster', obj.name, 'in directory', obj.root_dir, flush=True)
     obj.run()
     if verbose:
-        print('Finished running cluster', obj.name, 'in directory', obj.root_dir)
+        print('Finished running cluster', obj.name, 'in directory', obj.root_dir, flush=True)
     return obj
 
 

--- a/ariba/common.py
+++ b/ariba/common.py
@@ -3,9 +3,9 @@ import subprocess
 
 version = '0.6.0'
 
-def syscall(cmd, allow_fail=False, verbose=False):
+def syscall(cmd, allow_fail=False, verbose=False, verbose_filehandle=sys.stdout):
     if verbose:
-        print('syscall:', cmd, flush=True)
+        print('syscall:', cmd, flush=True, file=verbose_filehandle)
     try:
         subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as error:

--- a/ariba/common.py
+++ b/ariba/common.py
@@ -3,17 +3,18 @@ import subprocess
 
 version = '0.6.0'
 
-def syscall(cmd, allow_fail=False, verbose=False, verbose_filehandle=sys.stdout):
+def syscall(cmd, allow_fail=False, verbose=False, verbose_filehandle=sys.stdout, print_errors=True):
     if verbose:
         print('syscall:', cmd, flush=True, file=verbose_filehandle)
     try:
         subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as error:
         errors = error.output.decode()
-        print('The following command failed with exit code', error.returncode, file=sys.stderr)
-        print(cmd, file=sys.stderr)
-        print('\nThe output was:\n', file=sys.stderr)
-        print(errors, file=sys.stderr, flush=True)
+        if print_errors:
+            print('The following command failed with exit code', error.returncode, file=sys.stderr)
+            print(cmd, file=sys.stderr)
+            print('\nThe output was:\n', file=sys.stderr)
+            print(errors, file=sys.stderr, flush=True)
 
         if allow_fail:
             return False, errors

--- a/ariba/faidx.py
+++ b/ariba/faidx.py
@@ -1,10 +1,11 @@
+import sys
 import os
 from ariba import common
 
 
-def write_fa_subset(seq_names, infile, outfile, samtools_exe='samtools', verbose=False):
+def write_fa_subset(seq_names, infile, outfile, samtools_exe='samtools', verbose=False, verbose_filehandle=sys.stdout):
     if not os.path.exists(infile + '.fai'):
-        common.syscall(samtools_exe + ' faidx ' + infile, verbose=verbose)
+        common.syscall(samtools_exe + ' faidx ' + infile, verbose=verbose, verbose_filehandle=verbose_filehandle)
 
     if os.path.exists(outfile):
         os.path.unlink(outfile)

--- a/ariba/mapping.py
+++ b/ariba/mapping.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pysam
 from ariba import common
 
@@ -16,7 +17,8 @@ def run_bowtie2(
       samtools='samtools',
       bowtie2='bowtie2',
       bowtie2_preset='very-sensitive-local',
-      verbose=False
+      verbose=False,
+      verbose_filehandle=sys.stdout
     ):
 
     map_index = out_prefix + '.map_index'
@@ -47,16 +49,16 @@ def run_bowtie2(
         '- >', intermediate_bam
     ])
 
-    common.syscall(index_cmd, verbose=verbose)
-    common.syscall(map_cmd, verbose=verbose)
+    common.syscall(index_cmd, verbose=verbose, verbose_filehandle=verbose_filehandle)
+    common.syscall(map_cmd, verbose=verbose, verbose_filehandle=verbose_filehandle)
 
     if sort:
         threads = min(4, threads)
         thread_mem = int(500 / threads)
         sort_cmd = samtools + ' sort -@' + str(threads) + ' -m ' + str(thread_mem) + 'M ' + intermediate_bam + ' ' + out_prefix
         index_cmd = samtools + ' index ' + final_bam
-        common.syscall(sort_cmd, verbose=verbose)
-        common.syscall(index_cmd, verbose=verbose)
+        common.syscall(sort_cmd, verbose=verbose, verbose_filehandle=verbose_filehandle)
+        common.syscall(index_cmd, verbose=verbose, verbose_filehandle=verbose_filehandle)
     for fname in clean_files:
         os.unlink(fname)
 

--- a/ariba/tests/cluster_test.py
+++ b/ariba/tests/cluster_test.py
@@ -10,6 +10,7 @@ from ariba import cluster, flag
 
 modules_dir = os.path.dirname(os.path.abspath(cluster.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
+cluster.unittest = True
 
 
 def clean_cluster_dir(d, exclude=None):


### PR DESCRIPTION
- run each cluster in parallel
- changed the output of each cluster to write to its own log file, otherwise all output to stdout is a mess when threads>1
-  SPAdes can fail from spurious mapping causing clusters with only a few reads. When this happens, write a short message to stderr and point the user to a log file containing the output of spades. The old behaviour was intended for debugging and made users think that something really was wrong.