### PR TITLE
Provide getref prefix to run

### DIFF
--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -253,7 +253,7 @@ class RefGenesGetter:
         print('   ', final_tsv)
 
         print('\nYou can use them with ARIBA like this:')
-        print('ariba run --presabs', presence_absence_fa, '--varonly', variants_only_fa, '--metadata', final_tsv, ' reads_1.fq reads_2.fq output_directory\n')
+        print('ariba run --ref_prefix', outprefix, ' reads_1.fq reads_2.fq output_directory\n')
 
         print('If you use this downloaded data, please cite:')
         print('"The Comprehensive Antibiotic Resistance Database", McArthur et al 2013, PMID: 23650175')
@@ -294,7 +294,7 @@ class RefGenesGetter:
         shutil.rmtree(tmpdir)
 
         print('You can use it with ARIBA like this:')
-        print('ariba run --presabs', os.path.relpath(final_fasta), 'reads_1.fq reads_2.fq output_directory\n')
+        print('ariba run --ref_prefix', outprefix, 'reads_1.fq reads_2.fq output_directory\n')
         print('If you use this downloaded data, please cite:')
         print('"Identification of acquired antimicrobial resistance genes", Zankari et al 2012, PMID: 22782487\n')
 
@@ -323,7 +323,7 @@ class RefGenesGetter:
 
         print('Finished. Final genes file is called', final_fasta, end='\n\n')
         print('You can use it with ARIBA like this:')
-        print('ariba run --presabs', os.path.relpath(final_fasta), 'reads_1.fq reads_2.fq output_directory\n')
+        print('ariba run --ref_prefix', outprefix, 'reads_1.fq reads_2.fq output_directory\n')
         print('If you use this downloaded data, please cite:')
         print('"ARG-ANNOT, a new bioinformatic tool to discover antibiotic resistance genes in bacterial genomes",\nGupta et al 2014, PMID: 24145532\n')
 


### PR DESCRIPTION
Adds a new option--ref_prefix to the run task. Easier for the user, as don't need to specify all the input files explicitly.