### PR TITLE
Check all input files exist

### DIFF
--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -387,7 +387,7 @@ class Clusters:
     def write_versions_file(self, original_dir):
         with open('version_info.txt', 'w') as f:
             print('ARIBA version', common.version, 'run with this command:', file=f)
-            print(' '.join(sys.argv), file=f)
+            print(' '.join([sys.argv[0]] + ['run'] + sys.argv[1:]), file=f)
             print('from this directory:', original_dir, file=f)
             print(file=f)
             print('Versions of dependencies:\n', file=f)

--- a/ariba/tasks/run.py
+++ b/ariba/tasks/run.py
@@ -100,7 +100,7 @@ def run():
 
     if len(reads_not_found):
         print('\nThe following reads file(s) were not found:', file=sys.stderr)
-        print(*reads_not_found, sep='\n')
+        print(*reads_not_found, sep='\n', file=sys.stderr)
         print('Cannot continue', file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
- missing files are now written to stderr, instead of stdout.
- fix a typoe in log file saying how ariba was run (the word "run" was missing)