### PR TITLE
Various fixes

### DIFF
--- a/ariba/assembly.py
+++ b/ariba/assembly.py
@@ -244,6 +244,9 @@ class Assembly:
         common.syscall(cmd, verbose=True, verbose_filehandle=self.log_fh)
         self._rename_scaffolds(gapfilled_scaffolds, self.gapfilled_scaffolds, self.scaff_name_prefix)
         os.chdir(cwd)
+        if self.clean > 0:
+            print('Deleting GapFiller directory', self.gapfill_dir, file=self.log_fh)
+            shutil.rmtree(self.gapfill_dir)
 
 
     @staticmethod

--- a/ariba/assembly.py
+++ b/ariba/assembly.py
@@ -345,6 +345,14 @@ class Assembly:
             )
 
             self.scaff_graph_ok = self._parse_bam(self.sequences, self.final_assembly_bam, self.min_scaff_depth, self.max_insert)
+            print('Scaffolding graph is OK:', self.scaff_graph_ok, file=self.log_fh)
+
+            if self.clean:
+                for suffix in ['soft_clipped', 'unmapped_mates', 'scaff']:
+                    filename = self.final_assembly_bam + '.' + suffix
+                    print('Deleting file', filename, file=self.log_fh)
+                    os.unlink(filename)
+
 
         # This is to make this object picklable, to keep multithreading happy
         self.log_fh = None

--- a/ariba/assembly.py
+++ b/ariba/assembly.py
@@ -30,7 +30,7 @@ class Assembly:
       sspace_sd=0.4,
       reads_insert=500,
       extern_progs=None,
-      clean=1,
+      clean=True,
     ):
         self.reads1 = os.path.abspath(reads1)
         self.reads2 = os.path.abspath(reads2)
@@ -142,7 +142,7 @@ class Assembly:
 
         os.chdir(cwd)
 
-        if self.clean > 0:
+        if self.clean:
             print('Deleting assembly directory', self.assembler_dir, file=self.log_fh)
             shutil.rmtree(self.assembler_dir)
 
@@ -188,7 +188,7 @@ class Assembly:
         os.rename(sspace_scaffolds, self.scaffolder_scaffolds)
         os.chdir(cwd)
 
-        if self.clean > 0:
+        if self.clean:
             print('Deleting scaffolding directory', self.scaffold_dir, file=self.log_fh)
             shutil.rmtree(self.scaffold_dir)
 
@@ -244,7 +244,7 @@ class Assembly:
         common.syscall(cmd, verbose=True, verbose_filehandle=self.log_fh)
         self._rename_scaffolds(gapfilled_scaffolds, self.gapfilled_scaffolds, self.scaff_name_prefix)
         os.chdir(cwd)
-        if self.clean > 0:
+        if self.clean:
             print('Deleting GapFiller directory', self.gapfill_dir, file=self.log_fh)
             shutil.rmtree(self.gapfill_dir)
 

--- a/ariba/assembly.py
+++ b/ariba/assembly.py
@@ -176,11 +176,21 @@ class Assembly:
             '-s', self.assembly_contigs
         ])
 
-        sspace_scaffolds = os.path.abspath('standard_output.final.scaffolds.fasta')
         common.syscall(cmd, verbose=True, verbose_filehandle=self.log_fh)
-        os.chdir(self.working_dir)
-        os.symlink(os.path.relpath(sspace_scaffolds), os.path.basename(self.scaffolder_scaffolds))
+        sspace_scaffolds = os.path.abspath('standard_output.final.scaffolds.fasta')
+        sspace_log = os.path.abspath('standard_output.logfile.txt')
+        with open(sspace_log) as f:
+            print('\n_______________ SSPACE log __________________\n', file=self.log_fh)
+            for line in f:
+                print(line.rstrip(), file=self.log_fh)
+            print('_______________ End of SSPACE log __________________\n', file=self.log_fh)
+
+        os.rename(sspace_scaffolds, self.scaffolder_scaffolds)
         os.chdir(cwd)
+
+        if self.clean > 0:
+            print('Deleting scaffolding directory', self.scaffold_dir, file=self.log_fh)
+            shutil.rmtree(self.scaffold_dir)
 
 
     @staticmethod

--- a/ariba/cluster.py
+++ b/ariba/cluster.py
@@ -18,7 +18,7 @@ class Cluster:
       total_reads,
       total_reads_bases,
       logfile=None,
-      assembly_coverage=100,
+      assembly_coverage=50,
       assembly_kmer=21,
       assembler='spades',
       max_insert=1000,

--- a/ariba/cluster.py
+++ b/ariba/cluster.py
@@ -254,6 +254,9 @@ class Cluster:
 
             self.assembly.run()
             self.assembled_ok = self.assembly.assembled_ok
+            if self.clean > 0:
+                os.unlink(self.reads_for_assembly1)
+                os.unlink(self.reads_for_assembly2)
 
         if self.assembled_ok:
             print('\nAssembly was successful\n\nMapping reads to assembly:', file=self.log_fh, flush=True)

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -44,7 +44,7 @@ class Clusters:
       assembled_threshold=0.95,
       unique_threshold=0.03,
       bowtie2_preset='very-sensitive-local',
-      clean=1,
+      clean=True,
     ):
         self.refdata_dir = os.path.abspath(refdata_dir)
         self.refdata, self.cluster_ids = self._load_reference_data_from_dir(refdata_dir)
@@ -389,6 +389,8 @@ class Clusters:
             print('{:_^79}'.format(' Generating clusters '), flush=True)
         self._bam_to_clusters_reads()
         if self.clean:
+            if self.verbose:
+                print('Deleting BAM', self.bam, flush=True)
             os.unlink(self.bam)
 
         if len(self.cluster_to_dir) > 0:

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -428,7 +428,7 @@ class Clusters:
             print(self.catted_assembled_seqs_fasta)
         self._write_catted_assembled_seqs_fasta(self.catted_assembled_seqs_fasta)
 
-        clusters_log_file = os.path.join(self.outdir, 'log.clusters.txt')
+        clusters_log_file = os.path.join(self.outdir, 'log.clusters.gz')
         if self.verbose:
             print()
             print('{:_^79}'.format(' Catting cluster log files '), flush=True)

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -61,6 +61,8 @@ class Clusters:
         self.clusters_outdir = os.path.join(self.outdir, 'Clusters')
         self.clean = clean
 
+        self.logs_dir = os.path.join(self.outdir, 'Logs')
+
         self.assembler = assembler
         assert self.assembler in ['spades']
         self.assembly_kmer = assembly_kmer
@@ -100,7 +102,7 @@ class Clusters:
         self.cluster_read_counts = {} # gene name -> number of reads
         self.cluster_base_counts = {} # gene name -> number of bases
 
-        for d in [self.outdir, self.clusters_outdir]:
+        for d in [self.outdir, self.clusters_outdir, self.logs_dir]:
             try:
                 os.mkdir(d)
             except:
@@ -251,6 +253,7 @@ class Clusters:
 
         counter = 0
         cluster_list = []
+        self.log_files = []
 
         for seq_type in sorted(self.cluster_ids):
             if self.cluster_ids[seq_type] is None:
@@ -264,6 +267,7 @@ class Clusters:
                     print('Constructing cluster', seq_name + '.', counter, 'of', str(len(self.cluster_to_dir)))
                 new_dir = self.cluster_to_dir[seq_name]
                 self.refdata.write_seqs_to_fasta(os.path.join(new_dir, 'references.fa'), self.cluster_ids[seq_type][seq_name])
+                self.log_files.append(os.path.join(self.logs_dir, seq_name + '.log'))
 
                 cluster_list.append(cluster.Cluster(
                     new_dir,
@@ -271,6 +275,7 @@ class Clusters:
                     self.refdata,
                     self.cluster_read_counts[seq_name],
                     self.cluster_base_counts[seq_name],
+                    logfile=self.log_files[-1],
                     assembly_coverage=self.assembly_coverage,
                     assembly_kmer=self.assembly_kmer,
                     assembler=self.assembler,
@@ -307,7 +312,7 @@ class Clusters:
 
 
     @staticmethod
-    def _write_reports(clusters_in, tsv_out, xls_out):
+    def _write_reports(clusters_in, tsv_out, xls_out=None):
         columns = copy.copy(report.columns)
         columns[0] = '#' + columns[0]
 
@@ -329,7 +334,8 @@ class Clusters:
                 worksheet.append(line.split('\t'))
 
         pyfastaq.utils.close(f)
-        workbook.save(xls_out)
+        if xls_out is not None:
+            workbook.save(xls_out)
 
 
     def _write_catted_assembled_seqs_fasta(self, outfile):
@@ -349,26 +355,15 @@ class Clusters:
 
 
     def _clean(self):
-        if self.clean == 0:
+        if self.clean:
             if self.verbose:
-                print('   ... not deleting anything because --clean 0 used')
-            return
-
-        to_delete= [self.bam]
-
-        if self.clean == 2:
-            if self.verbose:
-                print('    rm -r', self.clusters_outdir)
+                print('Deleting clusters direcory', self.clusters_outdir)
                 shutil.rmtree(self.clusters_outdir)
-
-        for filename in to_delete:
-            if os.path.exists(filename):
-                if self.verbose:
-                    print('    rm', filename)
-                try:
-                    os.unlink(filename)
-                except:
-                    raise Error('Error deleting file', filename)
+                print('Deleting Logs directory', self.logs_dir)
+                shutil.rmtree(self.logs_dir)
+        else:
+            if self.verbose:
+                print('Not deleting anything because --noclean used')
 
 
     def write_versions_file(self, original_dir):
@@ -393,6 +388,8 @@ class Clusters:
             print('Finished mapping\n')
             print('{:_^79}'.format(' Generating clusters '), flush=True)
         self._bam_to_clusters_reads()
+        if self.clean:
+            os.unlink(self.bam)
 
         if len(self.cluster_to_dir) > 0:
             got_insert_data_ok = self._set_insert_size_data()
@@ -414,14 +411,12 @@ class Clusters:
             print('WARNING: no reads mapped to reference genes. Therefore no local assemblies will be run', file=sys.stderr)
 
         if self.verbose:
-            print('{:_^79}'.format(' Writing report files '), flush=True)
-            print(self.report_file_all_tsv)
-            print(self.report_file_all_xls)
-        self._write_reports(self.clusters, self.report_file_all_tsv, self.report_file_all_xls)
+            print('{:_^79}'.format(' Writing reports '), flush=True)
+            print('Making', self.report_file_all_tsv)
+        self._write_reports(self.clusters, self.report_file_all_tsv)
 
         if self.verbose:
-            print(self.report_file_filtered_prefix + '.tsv')
-            print(self.report_file_filtered_prefix + '.xls')
+            print('Making', self.report_file_filtered_prefix + '.tsv')
         rf = report_filter.ReportFilter(infile=self.report_file_all_tsv)
         rf.run(self.report_file_filtered_prefix)
 
@@ -431,7 +426,15 @@ class Clusters:
             print(self.catted_assembled_seqs_fasta)
         self._write_catted_assembled_seqs_fasta(self.catted_assembled_seqs_fasta)
 
+        clusters_log_file = os.path.join(self.outdir, 'log.clusters.txt')
         if self.verbose:
+            print()
+            print('{:_^79}'.format(' Catting cluster log files '), flush=True)
+            print('Writing file', clusters_log_file, flush=True)
+        common.cat_files(self.log_files, clusters_log_file)
+
+        if self.verbose:
+            print()
             print('{:_^79}'.format(' Cleaning files '), flush=True)
         self._clean()
 

--- a/ariba/common.py
+++ b/ariba/common.py
@@ -1,5 +1,6 @@
 import sys
 import subprocess
+import pyfastaq
 
 def syscall(cmd, allow_fail=False, verbose=False, verbose_filehandle=sys.stdout, print_errors=True):
     if verbose:
@@ -28,3 +29,16 @@ def decode(x):
     except:
         return x
     return s
+
+
+def cat_files(infiles, outfile):
+    '''Cats all files in list infiles into outfile'''
+    f_out = pyfastaq.utils.open_file_write(outfile)
+
+    for filename in infiles:
+        f_in = pyfastaq.utils.open_file_read(filename)
+        for line in f_in:
+            print(line, end='', file=f_out)
+        pyfastaq.utils.close(f_in)
+
+    pyfastaq.utils.close(f_out)

--- a/ariba/report_filter.py
+++ b/ariba/report_filter.py
@@ -212,6 +212,5 @@ class ReportFilter:
 
     def run(self, outprefix):
         self._filter_dicts()
-        self._write_report_xls(outprefix + '.xls')
         self._write_report_tsv(outprefix + '.tsv')
 

--- a/ariba/tasks/prepareref.py
+++ b/ariba/tasks/prepareref.py
@@ -4,9 +4,10 @@ from ariba import ref_preparer, external_progs, versions
 def run():
     parser = argparse.ArgumentParser(
         description = 'ARIBA: Antibiotic Resistance Identification By Assembly',
-        usage = 'ariba prepareref [options] <outdir>')
+        usage = 'ariba prepareref [options] <outdir>',
+        epilog = 'REQUIRED: either --ref_prefix, or at least one of --presabs, --varonly, --noncoding')
     input_group = parser.add_argument_group('input files options')
-    input_group.add_argument('--ref_prefix', help='Prefix of input files (same as was used with getref), to save listing --preseabs,--varonly ...etc. Will look for files called ref_prefix. followed by: metadata.tsv,presence_absence.fa,noncoding.fa,presence_absence.fa. Using this will cause these to be ignored if used: --presabs,--varonly,--noncoding,--metadata', metavar='FILENAME_PREFIX')
+    input_group.add_argument('--ref_prefix', help='Prefix of input files (same as was used with getref), to save listing --preseabs,--varonly ...etc. Will look for files called "ref_prefix." followed by: metadata.tsv,presence_absence.fa,noncoding.fa,variants_only.fa. Using this will cause these to be ignored if used: --presabs,--varonly,--noncoding,--metadata', metavar='FILENAME_PREFIX')
     input_group.add_argument('--presabs', help='FASTA file of presence absence genes', metavar='FILENAME')
     input_group.add_argument('--varonly', help='FASTA file of variants only genes', metavar='FILENAME')
     input_group.add_argument('--noncoding', help='FASTA file of noncoding sequences', metavar='FILENAME')

--- a/ariba/tasks/run.py
+++ b/ariba/tasks/run.py
@@ -19,7 +19,7 @@ def run():
     nucmer_group.add_argument('--nucmer_breaklen', type=int, help='Value to use for -breaklen when running nucmer [%(default)s]', default=200, metavar='INT')
 
     assembly_group = parser.add_argument_group('Assembly options')
-    assembly_group.add_argument('--assembly_cov', type=int, help='Target read coverage when sampling reads for assembly [%(default)s]', default=100, metavar='INT')
+    assembly_group.add_argument('--assembly_cov', type=int, help='Target read coverage when sampling reads for assembly [%(default)s]', default=50, metavar='INT')
     assembly_group.add_argument('--assembler_k', type=int, help='kmer size to use with assembler. You can use 0 to set kmer to 2/3 of the read length. Warning - lower kmers are usually better. [%(default)s]', metavar='INT', default=21)
     assembly_group.add_argument('--spades_other', help='Put options string to be used with spades in quotes. This will NOT be sanity checked. Do not use -k (see --assembler_k), --untrusted-contigs (it is always used), or -t [%(default)s]', default="--only-assembler -m 4", metavar="OPTIONS")
     assembly_group.add_argument('--min_scaff_depth', type=int, help='Minimum number of read pairs needed as evidence for scaffold link between two contigs. This is also the value used for sspace -k when scaffolding [%(default)s]', default=10, metavar='INT')

--- a/ariba/tasks/run.py
+++ b/ariba/tasks/run.py
@@ -30,7 +30,7 @@ def run():
     other_group.add_argument('--bowtie2_preset', choices=bowtie2_presets, help='Preset option for bowtie2 mapping [%(default)s]', default='very-sensitive-local', metavar='|'.join(bowtie2_presets))
     other_group.add_argument('--assembled_threshold', type=float, help='If proportion of gene assembled (regardless of into how many contigs) is at least this value then the flag gene_assembled is set [%(default)s]', default=0.95, metavar='FLOAT (between 0 and 1)')
     other_group.add_argument('--unique_threshold', type=float, help='If proportion of bases in gene assembled more than once is <= this value, then the flag unique_contig is set [%(default)s]', default=0.03, metavar='FLOAT (between 0 and 1)')
-    other_group.add_argument('--clean', type=int, choices=[0,1,2], help='Specify how much cleaning to do. 0=none, 1=some, 2=only keep the report [%(default)s]', default=1, metavar='INT')
+    other_group.add_argument('--noclean', action='store_true', help='Do not clean up intermediate files')
     other_group.add_argument('--verbose', action='store_true', help='Be verbose')
 
     options = parser.parse_args()
@@ -77,7 +77,7 @@ def run():
           assembled_threshold=options.assembled_threshold,
           unique_threshold=options.unique_threshold,
           bowtie2_preset=options.bowtie2_preset,
-          clean=options.clean,
+          clean=(not options.noclean),
         )
     c.run()
 

--- a/ariba/tasks/run.py
+++ b/ariba/tasks/run.py
@@ -21,7 +21,7 @@ def run():
     assembly_group = parser.add_argument_group('Assembly options')
     assembly_group.add_argument('--assembly_cov', type=int, help='Target read coverage when sampling reads for assembly [%(default)s]', default=100, metavar='INT')
     assembly_group.add_argument('--assembler_k', type=int, help='kmer size to use with assembler. You can use 0 to set kmer to 2/3 of the read length. Warning - lower kmers are usually better. [%(default)s]', metavar='INT', default=21)
-    assembly_group.add_argument('--spades_other', help='Put options string to be used with spades in quotes. This will NOT be sanity checked. Do not use -k or -t: for these options you should use the ariba run options --assembler_k and --threads [%(default)s]', default="--only-assembler", metavar="OPTIONS")
+    assembly_group.add_argument('--spades_other', help='Put options string to be used with spades in quotes. This will NOT be sanity checked. Do not use -k (see --assembler_k), --untrusted-contigs (it is always used), or -t [%(default)s]', default="--only-assembler -m 4", metavar="OPTIONS")
     assembly_group.add_argument('--min_scaff_depth', type=int, help='Minimum number of read pairs needed as evidence for scaffold link between two contigs. This is also the value used for sspace -k when scaffolding [%(default)s]', default=10, metavar='INT')
 
     other_group = parser.add_argument_group('Other options')

--- a/ariba/tasks/summary.py
+++ b/ariba/tasks/summary.py
@@ -4,13 +4,13 @@ import ariba
 def run():
     parser = argparse.ArgumentParser(
         description = 'Make a summry of ARIBA report files',
-        usage = 'ariba summary [options] <outfile> [report1.tsv report2.tsv ...]',
+        usage = 'ariba summary [options] <outprefix> [report1.tsv report2.tsv ...]',
         epilog = 'Files must be listed after the output file and/or the option --fofn must be used. If both used, all files in the filename specified by --fofn AND the files listed after the output file will be used as input. The input report files must be in tsv format, not xls.')
     parser.add_argument('-f', '--fofn', help='File of filenames of ariba reports in tsv format (not xls) to be summarised. Must be used if no input files listed after the outfile.', metavar='FILENAME')
     parser.add_argument('--no_var_columns', action='store_true', help='Do not keep a column for every variant. Default is to include them')
     parser.add_argument('--min_id', type=float, help='Minimum percent identity cutoff to count as assembled [%(default)s]', default=90, metavar='FLOAT')
     parser.add_argument('--no_filter', action='store_true', help='Do not filter rows or columns of output that are all 0 (by default, they are removed from the output)')
-    parser.add_argument('outfile', help='Name of output file. If file ends with ".xls", then an excel spreadsheet is written. Otherwise a tsv file is written')
+    parser.add_argument('outprefix', help='Prefix of output files')
     parser.add_argument('infiles', nargs='*', help='Files to be summarised')
     options = parser.parse_args()
     if len(options.infiles) == 0:

--- a/ariba/tests/common_test.py
+++ b/ariba/tests/common_test.py
@@ -1,0 +1,22 @@
+import unittest
+import os
+import filecmp
+from ariba import common
+
+modules_dir = os.path.dirname(os.path.abspath(common.__file__))
+data_dir = os.path.join(modules_dir, 'tests', 'data')
+
+
+class TestCommon(unittest.TestCase):
+    def test_cat_files(self):
+        '''test cat_files'''
+        infiles = [
+            os.path.join(data_dir, 'test_common_cat_files.in.1'),
+            os.path.join(data_dir, 'test_common_cat_files.in.2'),
+            os.path.join(data_dir, 'test_common_cat_files.in.3'),
+        ]
+        tmp_out = 'tmp.test.common_cat_files.out'
+        expected = os.path.join(data_dir, 'test_common_cat_files.out')
+        common.cat_files(infiles, tmp_out)
+        self.assertTrue(filecmp.cmp(expected, tmp_out, shallow=False))
+        os.unlink(tmp_out)

--- a/ariba/tests/data/test_common_cat_files.in.1
+++ b/ariba/tests/data/test_common_cat_files.in.1
@@ -1,0 +1,2 @@
+file1 line1
+file1 line2

--- a/ariba/tests/data/test_common_cat_files.in.2
+++ b/ariba/tests/data/test_common_cat_files.in.2
@@ -1,0 +1,3 @@
+file2 line1
+file2 line2
+file2 line3

--- a/ariba/tests/data/test_common_cat_files.in.3
+++ b/ariba/tests/data/test_common_cat_files.in.3
@@ -1,0 +1,1 @@
+file3 line1

--- a/ariba/tests/data/test_common_cat_files.out
+++ b/ariba/tests/data/test_common_cat_files.out
@@ -1,0 +1,6 @@
+file1 line1
+file1 line2
+file2 line1
+file2 line2
+file2 line3
+file3 line1

--- a/ariba/tests/report_filter_test.py
+++ b/ariba/tests/report_filter_test.py
@@ -332,6 +332,4 @@ class TestReportFilter(unittest.TestCase):
         rf.run(tmpprefix)
         self.assertTrue(filecmp.cmp(expected_file, tmpprefix + '.tsv', shallow=False))
         os.unlink(tmpprefix + '.tsv')
-        self.assertTrue(os.path.exists(tmpprefix + '.xls'))
-        os.unlink(tmpprefix + '.xls')
 


### PR DESCRIPTION
- clean files asap instead of waiting to the end of each cluster run
- do not write xls files
- keep spades log, warnings and errors
- pull all cluster logs into one final log file
- changed clean option from --clean N to clean everything unless new option --noclean is used
- lower assembly coverage used from 100X to 50X and set -m 4 in spades call