### PR TITLE
Stop returning error when all clusters successful

### DIFF
--- a/ariba/cluster.py
+++ b/ariba/cluster.py
@@ -134,14 +134,9 @@ class Cluster:
 
 
     def _atexit(self):
-        print('Error in cluster', self.name, '... Stopping!', file=sys.stderr, flush=True)
         if self.log_fh is not None:
             pyfastaq.utils.close(self.log_fh)
             self.log_fh = None
-        if self.fail_file is not None:
-            with open(self.fail_file, 'w') as f:
-                pass
-        os._exit(1)
 
 
     def _receive_signal(self, signum, stack):
@@ -434,3 +429,4 @@ class Cluster:
         print('\nMaking report lines', file=self.log_fh, flush=True)
         self.report_lines = report.report_lines(self)
         self._clean()
+        atexit.register(self._atexit)

--- a/ariba/cluster.py
+++ b/ariba/cluster.py
@@ -429,4 +429,4 @@ class Cluster:
         print('\nMaking report lines', file=self.log_fh, flush=True)
         self.report_lines = report.report_lines(self)
         self._clean()
-        atexit.register(self._atexit)
+        atexit.unregister(self._atexit)


### PR DESCRIPTION
On some OSs, if all jobs were successful, _atexit was getting run on all the clusters, os._exit(1) made it look like they all failed. This stops that behaviour. Still deals with raising errors and signals OK and cleans up temp directory.