### PR TITLE
Minor fixes

### DIFF
--- a/ariba/ext/fml-asm_ariba.cpp
+++ b/ariba/ext/fml-asm_ariba.cpp
@@ -172,12 +172,14 @@ int assemble(char *readsFile, char *fastaOut, char* logfileOut)
         // need to get the reads from the file every time, instead of before
         // the loop because fml_assemble() destroys them :(
         seqs = bseq_read(readsFile, &n_seqs);
-        fml_utg_t *utg;
-        utg = fml_assemble(&opt, n_seqs, seqs, &n_utg);
-        Assembly a(n_utg, utg, *minCountIter);
-        assemblies.push_back(a);
-        a.printStats(ofs);
-        fml_utg_destroy(n_utg, utg);
+        if (seqs && n_seqs > 0) {
+            fml_utg_t *utg;
+            utg = fml_assemble(&opt, n_seqs, seqs, &n_utg);
+            Assembly a(n_utg, utg, *minCountIter);
+            assemblies.push_back(a);
+            a.printStats(ofs);
+            fml_utg_destroy(n_utg, utg);
+        }
     }
 
     if (assemblies.size() == 0 || assemblies[0].numberOfContigs == 0)

--- a/ariba/tests/assembly_test.py
+++ b/ariba/tests/assembly_test.py
@@ -47,7 +47,7 @@ class TestAssembly(unittest.TestCase):
 
     def test_run_fermilite_fails(self):
         '''test _run_fermilite when it fails'''
-        reads = os.path.join(data_dir, 'assembly_run_fermilite_fails.reads.fq')
+        reads = os.path.join(data_dir, 'assembly_run_fermilite_fail.reads.fq')
         tmp_fa = 'tmp.test_run_fermilite_fails.fa'
         tmp_log = 'tmp.test_run_fermilite_fails.log'
         expected_log = os.path.join(data_dir, 'assembly_run_fermilite_fails.expected.log')

--- a/ariba/tests/assembly_test.py
+++ b/ariba/tests/assembly_test.py
@@ -21,8 +21,8 @@ class TestAssembly(unittest.TestCase):
         self.assertEqual(got, 42)
 
 
-    def test_check_spades_log_file(self):
-        '''test _check_spades_log_file'''
+    def _test_check_spades_log_file(self):
+        '''_test _check_spades_log_file'''
         good_file = os.path.join(data_dir, 'assembly_test_check_spades_log_file.log.good')
         bad_file = os.path.join(data_dir, 'assembly_test_check_spades_log_file.log.bad')
         self.assertTrue(assembly.Assembly._check_spades_log_file(good_file))


### PR DESCRIPTION
While preparing a Debian package for the 'new' ariba, I noticed that:
  - there was still a test that apparently needed a SPAdes installation present, and
  - in one of the fermi-lite extension's tests there was a typo in the input file name, leading to failed assertions during the build due to the number of input sequences being zero:
  
  ```
test _run_fermilite when it fails ... python3: mrope.c:230: mr_insert_multi: Assertion `len > 0 && s[len-1] == 0' failed.
   ```

This PR addresses both issues.