### PR TITLE
V2.0.0 bug fixes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ARIBA has the following dependencies, which need to be installed:
   * [CD-HIT][cdhit] version >= 4.6
   * [MASH][mash] version >= 1.0.2
   * [MUMmer][mummer] version >= 3.23
-  * [Samtools and BCFtools][samtools]  version >= 1.2
+  * [Samtools and BCFtools][samtools]  version >= 1.3
 
 
 Once the dependencies are installed, install ARIBA using pip:
@@ -64,7 +64,7 @@ to the following dependencies.
 For example, you could specify an exact version of a Samtools executable
 that you compiled and downloaded in your home directory (assuming BASH):
 
-    export ARIBA_SAMTOOLS=$HOME/samtools-1.2/samtools
+    export ARIBA_SAMTOOLS=$HOME/samtools-1.3/samtools
 
 
 ### Temporary files

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -490,9 +490,9 @@ class Clusters:
             except:
                 pass
 
-            if self.verbose:
-                print('Deleting reads store files', self.read_store.outfile + '[.tbi]')
             try:
+                if self.verbose:
+                    print('Deleting reads store files', self.read_store.outfile + '[.tbi]')
                 self.read_store.clean()
             except:
                 pass
@@ -523,6 +523,7 @@ class Clusters:
         os.chdir(self.outdir)
         self.write_versions_file(cwd)
         self._map_and_cluster_reads()
+        self.log_files = None
 
         if len(self.cluster_to_dir) > 0:
             got_insert_data_ok = self._set_insert_size_data()
@@ -563,12 +564,13 @@ class Clusters:
         self._write_catted_assembled_seqs_fasta(self.catted_assembled_seqs_fasta)
         self._write_catted_genes_matching_refs_fasta(self.catted_genes_matching_refs_fasta)
 
-        clusters_log_file = os.path.join(self.outdir, 'log.clusters.gz')
-        if self.verbose:
-            print()
-            print('{:_^79}'.format(' Catting cluster log files '), flush=True)
-            print('Writing file', clusters_log_file, flush=True)
-        common.cat_files(self.log_files, clusters_log_file)
+        if self.log_files is not None:
+            clusters_log_file = os.path.join(self.outdir, 'log.clusters.gz')
+            if self.verbose:
+                print()
+                print('{:_^79}'.format(' Catting cluster log files '), flush=True)
+                print('Writing file', clusters_log_file, flush=True)
+            common.cat_files(self.log_files, clusters_log_file)
 
         if self.verbose:
             print()

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -504,7 +504,7 @@ class Clusters:
     def write_versions_file(self, original_dir):
         with open('version_info.txt', 'w') as f:
             print('ARIBA run with this command:', file=f)
-            print(' '.join([sys.argv[0]] + ['run'] + sys.argv[1:]), file=f)
+            print(' '.join([sys.argv[0]] + sys.argv[1:]), file=f)
             print('from this directory:', original_dir, file=f)
             print(file=f)
             print(*self.version_report_lines, sep='\n', file=f)

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -100,6 +100,7 @@ class Clusters:
         self.report_file_filtered = os.path.join(self.outdir, 'report.tsv')
         self.catted_assembled_seqs_fasta = os.path.join(self.outdir, 'assembled_seqs.fa.gz')
         self.catted_genes_matching_refs_fasta = os.path.join(self.outdir, 'assembled_genes.fa.gz')
+        self.catted_assemblies_fasta = os.path.join(self.outdir, 'assemblies.fa.gz')
         self.threads = threads
         self.verbose = verbose
 
@@ -443,6 +444,21 @@ class Clusters:
         pyfastaq.utils.close(f)
 
 
+    def _write_catted_assemblies_fasta(self, outfile):
+        f = pyfastaq.utils.open_file_write(outfile)
+
+        for gene in sorted(self.clusters):
+            try:
+                seq_dict = self.clusters[gene].assembly.sequences
+            except:
+                continue
+
+            for seq_name in sorted(seq_dict):
+                print(seq_dict[seq_name], file=f)
+
+        pyfastaq.utils.close(f)
+
+
     def _write_catted_assembled_seqs_fasta(self, outfile):
         f = pyfastaq.utils.open_file_write(outfile)
 
@@ -563,6 +579,7 @@ class Clusters:
             print(self.catted_assembled_seqs_fasta, 'and', self.catted_genes_matching_refs_fasta, flush=True)
         self._write_catted_assembled_seqs_fasta(self.catted_assembled_seqs_fasta)
         self._write_catted_genes_matching_refs_fasta(self.catted_genes_matching_refs_fasta)
+        self._write_catted_assemblies_fasta(self.catted_assemblies_fasta)
 
         if self.log_files is not None:
             clusters_log_file = os.path.join(self.outdir, 'log.clusters.gz')

--- a/ariba/external_progs.py
+++ b/ariba/external_progs.py
@@ -41,13 +41,13 @@ prog_to_version_cmd = {
 
 
 min_versions = {
-    'bcftools': '1.2',
+    'bcftools': '1.3',
     'bowtie2': '2.1.0',
     'cdhit': '4.6',
     'cdhit2d': '4.6',
     'mash': '1.0.2',
     'nucmer': '3.1',
-    'samtools': '1.2',
+    'samtools': '1.3',
     #'spades': '3.5.0',
 }
 

--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -281,7 +281,7 @@ class RefGenesGetter:
         pyfastaq.utils.close(fout_tsv)
         print('\nFinished combining files\n')
         os.chdir(current_dir)
-        #shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir)
         print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
         print('You can use them with ARIBA like this:')
         print('ariba prepareref -f', final_fasta, '-m', final_tsv, 'output_directory\n')

--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -13,7 +13,7 @@ from ariba import common, card_record, vfdb_parser
 
 class RefGenesGetter:
     def __init__(self, ref_db, genetic_code=11):
-        allowed_ref_dbs = {'card', 'argannot', 'resfinder','vfdb'}
+        allowed_ref_dbs = {'card', 'argannot', 'plasmidfinder', 'resfinder','vfdb'}
         if ref_db not in allowed_ref_dbs:
             raise Error('Error in RefGenesGetter. ref_db must be one of: ' + str(allowed_ref_dbs) + ', but I got "' + ref_db)
         self.ref_db=ref_db
@@ -239,6 +239,58 @@ class RefGenesGetter:
         print('ariba prepareref -f', final_fasta, '-m', final_tsv, 'output_directory\n')
         print('If you use this downloaded data, please cite:')
         print('"ARG-ANNOT, a new bioinformatic tool to discover antibiotic resistance genes in bacterial genomes",\nGupta et al 2014, PMID: 24145532\n')
+
+
+    def _get_from_plasmidfinder(self, outprefix):
+        outprefix = os.path.abspath(outprefix)
+        final_fasta = outprefix + '.fa'
+        final_tsv = outprefix + '.tsv'
+        tmpdir = outprefix + '.tmp.download'
+        current_dir = os.getcwd()
+
+        try:
+            os.mkdir(tmpdir)
+            os.chdir(tmpdir)
+        except:
+            raise Error('Error mkdir/chdir ' + tmpdir)
+
+        zipfile = 'plasmidfinder.zip'
+        cmd = 'curl -X POST --data "folder=plasmidfinder&filename=plasmidfinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
+        print('Downloading data with:', cmd, sep='\n')
+        common.syscall(cmd)
+        common.syscall('unzip ' + zipfile)
+
+        print('Combining downloaded fasta files...')
+        fout_fa = pyfastaq.utils.open_file_write(final_fasta)
+        fout_tsv = pyfastaq.utils.open_file_write(final_tsv)
+        name_count = {}
+
+        for filename in os.listdir(tmpdir):
+            if filename.endswith('.fsa'):
+                print('   ', filename)
+                file_reader = pyfastaq.sequences.file_reader(os.path.join(tmpdir, filename))
+                for seq in file_reader:
+                    original_id = seq.id
+                    seq.id = seq.id.replace('_', '.', 1)
+                    if seq.id in name_count:
+                        name_count[seq.id] += 1
+                        seq.id = seq.id + '.' + str(name_count[seq.id])
+                    else:
+                        name_count[seq.id] = 1
+
+                    print(seq, file=fout_fa)
+                    print(seq.id, '0', '0', '.', '.', 'Original name was ' + original_id, sep='\t', file=fout_tsv)
+
+        pyfastaq.utils.close(fout_fa)
+        pyfastaq.utils.close(fout_tsv)
+        print('\nFinished combining files\n')
+        os.chdir(current_dir)
+        #shutil.rmtree(tmpdir)
+        print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
+        print('You can use them with ARIBA like this:')
+        print('ariba prepareref -f', final_fasta, '-m', final_tsv, 'output_directory\n')
+        print('If you use this downloaded data, please cite:')
+        print('"PlasmidFinder and pMLST: in silico detection and typing of plasmids", Carattoli et al 2014, PMID: 24777092\n')
 
 
     def _get_from_vfdb(self, outprefix):

--- a/ariba/ref_preparer.py
+++ b/ariba/ref_preparer.py
@@ -86,9 +86,15 @@ class RefPreparer:
             if new_key in key_count:
                 if new_key in new_clusters:
                     assert key_count[new_key] == 1
-                    assert new_key + '_1' not in new_clusters
-                    new_clusters[new_key + '_1'] = new_clusters[new_key]
+
+                    i = 1
+                    while new_key + '_' + str(i) in new_clusters:
+                        i += 1
+
+                    assert new_key + '_' + str(i) not in new_clusters
+                    new_clusters[new_key + '_' + str(i)] = new_clusters[new_key]
                     del new_clusters[new_key]
+                    key_count[new_key] = i
 
                 key_count[new_key] += 1
                 new_name = new_key + '_' + str(key_count[new_key])
@@ -98,7 +104,6 @@ class RefPreparer:
 
             assert new_name not in new_clusters
             new_clusters[new_name] = name_set
-
 
         return new_clusters
 

--- a/ariba/report.py
+++ b/ariba/report.py
@@ -212,11 +212,11 @@ def _report_lines_for_one_contig(cluster, contig_name, ref_cov_per_contig, pymum
                 smtls_alt_nt = ';'.join(smtls_alt_nt) if len(smtls_alt_nt) else '.'
                 smtls_alt_depth = ';'.join(smtls_alt_depth) if len(smtls_alt_depth) else '.'
                 samtools_columns = [
-                        str(contributing_vars[0].ref_start), #ref_start
-                        str(contributing_vars[0].ref_end), # ref_end
+                        str(contributing_vars[0].ref_start + 1), #ref_start
+                        str(contributing_vars[0].ref_end + 1), # ref_end
                         ';'.join([x.ref_base for x in contributing_vars]), # ref_nt
-                        str(contributing_vars[0].qry_start),  # ctg_start
-                        str(contributing_vars[0].qry_end),  #ctg_end
+                        str(contributing_vars[0].qry_start + 1),  # ctg_start
+                        str(contributing_vars[0].qry_end + 1),  #ctg_end
                         ';'.join([x.qry_base for x in contributing_vars]), #ctg_nt
                         smtls_total_depth,
                         smtls_alt_nt,

--- a/ariba/samtools_variants.py
+++ b/ariba/samtools_variants.py
@@ -39,7 +39,7 @@ class SamtoolsVariants:
         tmp_vcf = self.vcf_file + '.tmp'
         cmd = ' '.join([
             self.samtools_exe, 'mpileup',
-            '-t INFO/DPR,DV',
+            '-t INFO/AD',
             '-A',
             '-f', self.ref_fa,
             '-u',
@@ -56,7 +56,7 @@ class SamtoolsVariants:
             tmp_vcf,
             '|',
             self.bcftools_exe, 'query',
-            r'''-f '%CHROM\t%POS\t%REF\t%ALT\t%DP\t%DPR]\n' ''',
+            r'''-f '%CHROM\t%POS\t%REF\t%ALT\t%DP\t%AD]\n' ''',
             '>',
             self.read_depths_file + '.tmp'
         ])
@@ -71,10 +71,7 @@ class SamtoolsVariants:
             tmp_vcf,
             '|',
             self.bcftools_exe, 'filter',
-            '-i', '"MIN(DP)>=' + str(self.bcf_min_dp),
-                  ' & MIN(DV)>=' + str(self.bcf_min_dv),
-                  ' & MIN(DV/DP)>=' + str(self.bcf_min_dv_over_dp),
-                  ' & QUAL >=', str(self.bcf_min_qual), '"',
+            '-i', '"SUM(AD)>=5 & MIN(AD)/DP>=0.1"',
             '-o', self.vcf_file
         ])
 

--- a/ariba/summary_cluster.py
+++ b/ariba/summary_cluster.py
@@ -209,7 +209,7 @@ class SummaryCluster:
                 nuc_to_depth = dict(zip(nucleotides, depths))
                 total_depth = sum(depths)
                 var_depth = nuc_to_depth.get(var_nucleotide, 0)
-                percent_depth = 100 * var_depth / total_depth
+                percent_depth = round(100 * var_depth / total_depth, 1)
             except:
                 return None
 

--- a/ariba/tests/cluster_test.py
+++ b/ariba/tests/cluster_test.py
@@ -160,10 +160,10 @@ class TestCluster(unittest.TestCase):
         c.run()
 
         expected = [
-            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t1\tSNP\tn\tA14T\t1\tA14T\tSNP\t13\t13\tA\t73\t73\tT\t19\t.\t19\tnoncoding1:0:0:A14T:.:ref has wild type, reads has variant so should report\tgeneric description of noncoding1',
-            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t0\t.\tn\t.\t0\tG61T\tSNP\t60\t60\tG\t120\t120\tT\t24\t.\t24\t.\tgeneric description of noncoding1',
-            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t0\t.\tn\t.\t0\t.82C\tINS\t81\t81\t.\t142\t142\tC\t23\t.\t23\t.\tgeneric description of noncoding1',
-            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t0\t.\tn\t.\t0\tT108.\tDEL\t107\t107\tT\t167\t167\t.\t17\t.\t17\t.\tgeneric description of noncoding1',
+            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t1\tSNP\tn\tA14T\t1\tA14T\tSNP\t14\t14\tA\t74\t74\tT\t19\t.\t19\tnoncoding1:0:0:A14T:.:ref has wild type, reads has variant so should report\tgeneric description of noncoding1',
+            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t0\t.\tn\t.\t0\tG61T\tSNP\t61\t61\tG\t121\t121\tT\t24\t.\t24\t.\tgeneric description of noncoding1',
+            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t0\t.\tn\t.\t0\t.82C\tINS\t82\t82\t.\t143\t143\tC\t23\t.\t23\t.\tgeneric description of noncoding1',
+            'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t0\t.\tn\t.\t0\tT108.\tDEL\t108\t108\tT\t168\t168\t.\t17\t.\t17\t.\tgeneric description of noncoding1',
             'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t1\tSNP\tn\tA6G\t1\t.\t.\t6\t6\tG\t66\t66\tG\t19\t.\t19\tnoncoding1:0:0:A6G:.:variant in ref and reads so should report\tgeneric description of noncoding1',
             'noncoding1\t0\t0\t531\t72\tcluster_name\t120\t120\t95.87\tcluster_name.scaffold.1\t234\t15.4\t1\tSNP\tn\tG9T\t0\t.\t.\t9\t9\tG\t69\t69\tG\t19\t.\t19\tnoncoding1:0:0:G9T:.:wild type in ref and reads\tgeneric description of noncoding1'
         ]
@@ -184,8 +184,8 @@ class TestCluster(unittest.TestCase):
         c.run()
 
         expected = [
-            'presence_absence1\t1\t0\t539\t64\tcluster_name\t96\t96\t97.92\tcluster_name.scaffold.1\t213\t15.0\t1\tSNP\tp\tA10V\t1\tA10V\tNONSYN\t28\t28\tC\t83\t83\tT\t22\t.\t22\tpresence_absence1:1:0:A10V:.:Ref has wild, reads have variant so report\tGeneric description of presence_absence1',
-            'presence_absence1\t1\t0\t539\t64\tcluster_name\t96\t96\t97.92\tcluster_name.scaffold.1\t213\t15.0\t0\t.\tp\t.\t0\t.\tSYN\t53\t53\tT\t108\t108\tC\t32\t.\t32\t.\tGeneric description of presence_absence1',
+            'presence_absence1\t1\t0\t539\t64\tcluster_name\t96\t96\t97.92\tcluster_name.scaffold.1\t213\t15.0\t1\tSNP\tp\tA10V\t1\tA10V\tNONSYN\t29\t29\tC\t84\t84\tT\t22\t.\t22\tpresence_absence1:1:0:A10V:.:Ref has wild, reads have variant so report\tGeneric description of presence_absence1',
+            'presence_absence1\t1\t0\t539\t64\tcluster_name\t96\t96\t97.92\tcluster_name.scaffold.1\t213\t15.0\t0\t.\tp\t.\t0\t.\tSYN\t54\t54\tT\t109\t109\tC\t32\t.\t32\t.\tGeneric description of presence_absence1',
 
             'presence_absence1\t1\t0\t539\t64\tcluster_name\t96\t96\t97.92\tcluster_name.scaffold.1\t213\t15.0\t1\tSNP\tp\tR3S\t0\t.\t.\t7\t9\tC;G;C\t62\t64\tC;G;C\t18;17;17\t.;.;.\t18;17;17\tpresence_absence1:1:0:R3S:.:Ref and assembly have wild type\tGeneric description of presence_absence1',
 

--- a/ariba/tests/clusters_test.py
+++ b/ariba/tests/clusters_test.py
@@ -204,6 +204,33 @@ class TestClusters(unittest.TestCase):
         os.unlink(tmp_tsv)
 
 
+    def test_write_catted_assemblies_fasta(self):
+        '''test _write_catted_assemblies_fasta'''
+        seq1 = pyfastaq.sequences.Fasta('seq1', 'ACGT')
+        seq2 = pyfastaq.sequences.Fasta('seq2', 'TTTT')
+        seq3 = pyfastaq.sequences.Fasta('seq3', 'AAAA')
+        class FakeAssembly:
+            def __init__(self, seqs):
+                if seqs is not None:
+                    self.sequences = {x.id: x for x in seqs}
+
+        class FakeCluster:
+            def __init__(self, seqs):
+                self.assembly = FakeAssembly(seqs)
+
+        self.clusters.clusters = {
+            'cluster1': FakeCluster([seq1, seq2]),
+            'cluster2': FakeCluster([seq3]),
+            'cluster3': FakeCluster(None),
+        }
+
+        tmp_file = 'tmp.test_write_catted_assemblies_fasta.fa'
+        self.clusters._write_catted_assemblies_fasta(tmp_file)
+        expected = os.path.join(data_dir, 'clusters_test_write_catted_assemblies_fasta.expected.out.fa')
+        self.assertTrue(filecmp.cmp(expected, tmp_file, shallow=False))
+        os.unlink(tmp_file)
+
+
     def test_write_catted_assembled_seqs_fasta(self):
         '''test _write_catted_assembled_seqs_fasta'''
         seq1 = pyfastaq.sequences.Fasta('seq1', 'ACGT')

--- a/ariba/tests/data/clusters_test_write_catted_assemblies_fasta.expected.out.fa
+++ b/ariba/tests/data/clusters_test_write_catted_assemblies_fasta.expected.out.fa
@@ -1,0 +1,6 @@
+>seq1
+ACGT
+>seq2
+TTTT
+>seq3
+AAAA

--- a/ariba/tests/data/samtools_variants_test_make_vcf_and_read_depths_files.expected.vcf
+++ b/ariba/tests/data/samtools_variants_test_make_vcf_and_read_depths_files.expected.vcf
@@ -1,8 +1,8 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
-##samtoolsVersion=1.2+htslib-1.2.1
-##samtoolsCommand=samtools mpileup -t INFO/DPR,DV -A -f cluster_test_make_assembly_vcf.assembly.fa -u -v cluster_test_make_assembly_vcf.assembly.bam
-##reference=file://cluster_test_make_assembly_vcf.assembly.fa
+##samtoolsVersion=1.3+htslib-1.3
+##samtoolsCommand=samtools mpileup -t INFO/AD -A -f /home/ubuntu/sanger-pathogens/ariba/ariba/tests/data/samtools_variants_test_make_vcf_and_read_depths_files.assembly.fa -u -v /home/ubuntu/sanger-pathogens/ariba/ariba/tests/data/samtools_variants_test_make_vcf_and_read_depths_files.bam
+##reference=file:///home/ubuntu/sanger-pathogens/ariba/ariba/tests/data/samtools_variants_test_make_vcf_and_read_depths_files.assembly.fa
 ##contig=<ID=16__cat_2_M35190.scaffold.1,length=444>
 ##contig=<ID=16__cat_2_M35190.scaffold.2,length=400>
 ##contig=<ID=16__cat_2_M35190.scaffold.3,length=398>
@@ -11,7 +11,7 @@
 ##contig=<ID=16__cat_2_M35190.scaffold.6,length=180>
 ##contig=<ID=16__cat_2_M35190.scaffold.7,length=133>
 ##contig=<ID=16__cat_2_M35190.scaffold.8,length=133>
-##ALT=<ID=X,Description="Represents allele(s) other than observed.">
+##ALT=<ID=*,Description="Represents allele(s) other than observed.">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##INFO=<ID=IDV,Number=1,Type=Integer,Description="Maximum number of reads supporting an indel">
 ##INFO=<ID=IMF,Number=1,Type=Float,Description="Maximum fraction of reads supporting an indel">
@@ -24,8 +24,7 @@
 ##INFO=<ID=SGB,Number=1,Type=Float,Description="Segregation based metric.">
 ##INFO=<ID=MQ0F,Number=1,Type=Float,Description="Fraction of MQ0 reads (smaller is better)">
 ##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
-##FORMAT=<ID=DV,Number=1,Type=Integer,Description="Number of high-quality non-reference bases">
-##INFO=<ID=DPR,Number=R,Type=Integer,Description="Number of high-quality bases observed for each allele">
+##INFO=<ID=AD,Number=R,Type=Integer,Description="Total allelic depths">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##INFO=<ID=ICB,Number=1,Type=Float,Description="Inbreeding Coefficient Binomial test (bigger is better)">
 ##INFO=<ID=HOB,Number=1,Type=Float,Description="Bias in the number of HOMs number (smaller is better)">
@@ -33,12 +32,12 @@
 ##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
 ##INFO=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward , ref-reverse, alt-forward and alt-reverse bases">
 ##INFO=<ID=MQ,Number=1,Type=Integer,Description="Average mapping quality">
-##bcftools_callVersion=1.2+htslib-1.2.1
-##bcftools_callCommand=call -m -v z.vcf
-##bcftools_filterVersion=1.2+htslib-1.2.1
-##bcftools_filterCommand=filter -i 'MIN(DP)>=10 & MIN(DV)>=5 & MIN(DV/DP)>=0.3 &  QUAL >= 20'
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	cluster_test_make_assembly_vcf.assembly.bam
-16__cat_2_M35190.scaffold.1	93	.	T	A	222	PASS	DP=123;VDB=0.00672125;SGB=-0.693147;RPB=0.359049;MQB=0.976548;MQSB=1.38527e-20;BQB=0.957743;MQ0F=0;DPR=65,58;ICB=1;HOB=0.5;AC=1;AN=2;DP4=35,30,25,33;MQ=41	GT:PL:DV	0/1:255,0,255:58
-16__cat_2_M35190.scaffold.1	180	.	A	T	222	PASS	DP=86;VDB=0.102578;SGB=-0.693147;RPB=0.885638;MQB=0.976909;MQSB=7.02391e-09;BQB=1;MQ0F=0;DPR=41,45;ICB=1;HOB=0.5;AC=1;AN=2;DP4=17,24,19,26;MQ=27	GT:PL:DV	0/1:255,0,255:45
-16__cat_2_M35190.scaffold.1	264	.	G	C	119	PASS	DP=97;VDB=0.0562559;SGB=-0.693146;RPB=0.389539;MQB=0.007282;MQSB=0.00207736;BQB=0.950442;MQ0F=0;DPR=53,44;ICB=1;HOB=0.5;AC=1;AN=2;DP4=20,33,23,21;MQ=23	GT:PL:DV	0/1:152,0,244:44
-16__cat_2_M35190.scaffold.6	94	.	T	G	171	PASS	DP=99;VDB=0.0786476;SGB=-0.693146;RPB=0.837015;MQB=0.737682;MQSB=1.09416e-07;BQB=1;MQ0F=0.262626;DPR=56,43;ICB=1;HOB=0.5;AC=1;AN=2;DP4=28,28,22,21;MQ=21	GT:PL:DV	0/1:204,0,222:43
+##bcftools_callVersion=1.3+htslib-1.3
+##bcftools_callCommand=call -m -v /home/ubuntu/sanger-pathogens/ariba/tmp.test_make_vcf_and_read_depths_files.vcf.tmp
+##bcftools_filterVersion=1.3+htslib-1.3
+##bcftools_filterCommand=filter -i 'SUM(AD)>=5 & MIN(AD)/DP>=0.1' -o /home/ubuntu/sanger-pathogens/ariba/tmp.test_make_vcf_and_read_depths_files.vcf
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	/home/ubuntu/sanger-pathogens/ariba/ariba/tests/data/samtools_variants_test_make_vcf_and_read_depths_files.bam
+16__cat_2_M35190.scaffold.1	93	.	T	A	222	PASS	DP=123;AD=65,58;VDB=0.00672125;SGB=-0.693147;RPB=0.359049;MQB=0.976548;MQSB=1.38527e-20;BQB=0.957743;MQ0F=0;ICB=1;HOB=0.5;AC=1;AN=2;DP4=35,30,25,33;MQ=41	GT:PL	0/1:255,0,255
+16__cat_2_M35190.scaffold.1	180	.	A	T	222	PASS	DP=86;AD=41,45;VDB=0.102578;SGB=-0.693147;RPB=0.885638;MQB=0.976909;MQSB=7.02391e-09;BQB=1;MQ0F=0;ICB=1;HOB=0.5;AC=1;AN=2;DP4=17,24,19,26;MQ=27	GT:PL	0/1:255,0,255
+16__cat_2_M35190.scaffold.1	264	.	G	C	119	PASS	DP=97;AD=53,44;VDB=0.0562559;SGB=-0.693146;RPB=0.389539;MQB=0.007282;MQSB=0.00207736;BQB=0.950442;MQ0F=0;ICB=1;HOB=0.5;AC=1;AN=2;DP4=20,33,23,21;MQ=23	GT:PL	0/1:152,0,244
+16__cat_2_M35190.scaffold.6	94	.	T	G	171	PASS	DP=99;AD=56,43;VDB=0.0786476;SGB=-0.693146;RPB=0.837015;MQB=0.737682;MQSB=1.09416e-07;BQB=1;MQ0F=0.262626;ICB=1;HOB=0.5;AC=1;AN=2;DP4=28,28,22,21;MQ=21	GT:PL	0/1:204,0,222

--- a/ariba/tests/ref_preparer_test.py
+++ b/ariba/tests/ref_preparer_test.py
@@ -22,6 +22,15 @@ class TestRefPreparer(unittest.TestCase):
            '7': {'prefix1.fgh', 'prefix1.ijk', 'something_else_again.abc'},
            '8': {'xyz.1', 'xyz.2', 'abcdefgh'},
            '9': {'a.foo', 'a.bar'},
+           '10': {'abc_1.1'},
+           '11': {'abc.2'},
+           '12': {'abc.3'},
+           '13': {'abc.4'},
+           '14': {'def.1'},
+           '15': {'def_1.2'},
+           '16': {'def_2.3'},
+           '17': {'def.4'},
+           '18': {'def.5'},
         }
 
         expected = {
@@ -35,9 +44,17 @@ class TestRefPreparer(unittest.TestCase):
             'prefix1+_2': {'prefix1.fgh', 'prefix1.ijk', 'something_else_again.abc'},
             'xyz+': {'xyz.1', 'xyz.2', 'abcdefgh'},
             'cluster_3': {'a.foo', 'a.bar'},
+            'abc_1': {'abc_1.1'},
+            'abc_2': {'abc.2'},
+            'abc_3': {'abc.3'},
+            'abc_4': {'abc.4'},
+            'def_1': {'def_1.2'},
+            'def_2': {'def_2.3'},
+            'def_3': {'def.1'},
+            'def_4': {'def.4'},
+            'def_5': {'def.5'},
         }
 
-        self.maxDiff = None
         got = ref_preparer.RefPreparer._rename_clusters(clusters_in)
         self.assertEqual(expected, got)
 

--- a/scripts/ariba
+++ b/scripts/ariba
@@ -162,7 +162,7 @@ subparser_summary.add_argument('-f', '--fofn', help='File of filenames of ariba 
 subparser_summary.add_argument('--preset', choices=summary_presets, help='Shorthand for setting --cluster_cols,--col_filter,--row_filter,--known_vars,--novel_vars. Using this overrides those options', metavar='|'.join(summary_presets))
 subparser_summary.add_argument('--cluster_cols', help='Comma separated list of cluster columns to include. Choose from: assembled, match, ref_seq, pct_id, known_var, novel_var [%(default)s]', default='match', metavar='col1,col2,...')
 subparser_summary.add_argument('--col_filter', choices=['y', 'n'], default='y', help='Choose whether columns where all values are "no" or "NA" are removed [%(default)s]', metavar='y|n')
-subparser_summary.add_argument('--het', action='store_true', help='For known noncoding SNPs, report if they are heterozygous or not, and the %of reads supporting the variant type')
+subparser_summary.add_argument('--het', action='store_true', help='For known noncoding SNPs, report if they are heterozygous or not, and the percent of reads supporting the variant type')
 subparser_summary.add_argument('--row_filter', choices=['y', 'n'], default='y', help='Choose whether rows where all values are "no" or "NA" are removed [%(default)s]', metavar='y|n')
 subparser_summary.add_argument('--var_cols', help='Comma separated list of variant columns to include. Choose from: groups, grouped, ungrouped, novel [none by default]', metavar='col1,col2,...', default='')
 subparser_summary.add_argument('--min_id', type=float, help='Minimum percent identity cutoff to count as assembled [%(default)s]', default=90, metavar='FLOAT')

--- a/scripts/ariba
+++ b/scripts/ariba
@@ -42,7 +42,7 @@ subparser_flag.set_defaults(func=ariba.tasks.flag.run)
 
 
 #---------------------------- getref ------------------------------------
-allowed_dbs = ['argannot', 'card', 'resfinder','vfdb']
+allowed_dbs = ['argannot', 'card', 'plasmidfinder', 'resfinder','vfdb']
 subparser_getref = subparsers.add_parser(
     'getref',
     help='Download reference data',
@@ -50,7 +50,7 @@ subparser_getref = subparsers.add_parser(
     description='Download reference data from one of a few supported public resources',
 )
 subparser_getref.add_argument('--genetic_code', type=int, help='Number of genetic code to use. Currently supported 1,4,11 [%(default)s]', choices=[1,4,11], default=11, metavar='INT')
-subparser_getref.add_argument('db', help='Database to download. Must be one of: ' + ' '.join(allowed_dbs), choices=allowed_dbs)
+subparser_getref.add_argument('db', help='Database to download. Must be one of: ' + ' '.join(allowed_dbs), choices=allowed_dbs, metavar="DB name")
 subparser_getref.add_argument('outprefix', help='Prefix of output filenames')
 subparser_getref.set_defaults(func=ariba.tasks.getref.run)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ fermilite_mod = Extension(
 setup(
     ext_modules=[minimap_mod, fermilite_mod],
     name='ariba',
-    version='2.0.0',
+    version='2.1.0',
     description='ARIBA: Antibiotic Resistance Identification By Assembly',
     packages = find_packages(),
     package_data={'ariba': ['test_run_data/*']},


### PR DESCRIPTION
Changes:
- report het snps for noncoding sequences
- add plasmidfinder
- write all assemblies to a single file at the end
- better naming of clusters when using argannot

Bug fixes:
- off by one error in ref and contig positions of variants in some report lines
- samtools/bcftools parameters changed for snp calling. Diploid assumption was making some Q scores zero, so got filtered out when they shouldn't have
- cluster naming fixed (was getting broken by vfdb)
- catch when no proper pairs mapped and nothing gets assembled. Writes empty report instead of crashing.
