### PR TITLE
Aln2meta fix

### DIFF
--- a/ariba/aln_to_metadata.py
+++ b/ariba/aln_to_metadata.py
@@ -11,7 +11,6 @@ class AlnToMetadata:
       vars_file,
       refs_are_coding,
       refs_are_variant_only,
-      cluster_rep_name,
       genetic_code=11,
     ):
         self.padded_seqs = AlnToMetadata._load_aln_file(aln_file)
@@ -19,7 +18,6 @@ class AlnToMetadata:
         self.refs_are_variant_only = refs_are_variant_only
         self.variants = AlnToMetadata._load_vars_file(vars_file, self.refs_are_coding)
         self.genetic_code = genetic_code
-        self.cluster_rep_name = cluster_rep_name
 
 
     @classmethod
@@ -248,8 +246,6 @@ class AlnToMetadata:
 
 
     def run(self, outprefix):
-        if self.cluster_rep_name not in self.padded_seqs:
-            raise Error('Sequence name "' + self.cluster_rep_name + '" to be used as cluster representative not found. Cannot continue')
         original_code = pyfastaq.sequences.genetic_code
         pyfastaq.sequences.genetic_code = self.genetic_code
         unpadded_seqs = AlnToMetadata._make_unpadded_seqs(self.padded_seqs)

--- a/ariba/tasks/aln2meta.py
+++ b/ariba/tasks/aln2meta.py
@@ -7,7 +7,7 @@ def run(options):
       options.aln_fasta,
       options.variants_tsv,
       options.coding_or_non == 'coding',
-      options.cluster_rep,
+      options.variant_only,
       genetic_code=options.genetic_code
     )
     aln_to_meta.run(options.outprefix)

--- a/ariba/tests/aln_to_metadata_test.py
+++ b/ariba/tests/aln_to_metadata_test.py
@@ -373,7 +373,7 @@ class TestAlnToMetadata(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'aln_to_metadata_run_coding.in.tsv')
         tsv_expected = os.path.join(data_dir, 'aln_to_metadata_run_coding.out.tsv')
         cluster_expected = os.path.join(data_dir, 'aln_to_metadata_run_coding.out.cluster')
-        a_to_m = aln_to_metadata.AlnToMetadata(fa_in, tsv_in, True, False, 'seq3')
+        a_to_m = aln_to_metadata.AlnToMetadata(fa_in, tsv_in, True, False)
         outprefix = 'tmp.test.aln_to_metadata.run_coding'
         a_to_m.run(outprefix)
         self.assertTrue(filecmp.cmp(tsv_expected, outprefix + '.tsv', shallow=False))
@@ -391,7 +391,7 @@ class TestAlnToMetadata(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'aln_to_metadata_run_noncoding.in.tsv')
         tsv_expected = os.path.join(data_dir, 'aln_to_metadata_run_noncoding.out.tsv')
         cluster_expected = os.path.join(data_dir, 'aln_to_metadata_run_noncoding.out.cluster')
-        a_to_m = aln_to_metadata.AlnToMetadata(fa_in, tsv_in, False, True, 'seq2')
+        a_to_m = aln_to_metadata.AlnToMetadata(fa_in, tsv_in, False, True)
         outprefix = 'tmp.test.aln_to_metadata.run_noncoding'
         a_to_m.run(outprefix)
         self.assertTrue(filecmp.cmp(tsv_expected, outprefix + '.tsv', shallow=False))

--- a/scripts/ariba
+++ b/scripts/ariba
@@ -16,15 +16,15 @@ coding_choices = ['coding', 'noncoding']
 subparser_aln2meta = subparsers.add_parser(
     'aln2meta',
     help='Converts multi-aln fasta and SNPs to metadata',
-    usage='ariba aln2meta [options] <aln_fasta> <variants_tsv> <(non)coding> <cluster_rep> <outprefix>',
+    usage='ariba aln2meta [options] <aln_fasta> <variants_tsv> <(non)coding> <outprefix>',
     description='Make metadata input to prepareref, using multialignment and SNPs',
 )
 
 subparser_aln2meta.add_argument('--genetic_code', type=int, help='Number of genetic code to use. Currently supported 1,4,11 [%(default)s]', choices=[1,4,11], default=11, metavar='INT')
+subparser_aln2meta.add_argument('--variant_only', action='store_true', help='Use this to flag all sequences as variant only. By default they are considered to be presence/absence')
 subparser_aln2meta.add_argument('aln_fasta', help='Multi-fasta file of alignments')
 subparser_aln2meta.add_argument('variants_tsv', help='TSV file of variants information')
 subparser_aln2meta.add_argument('coding_or_non', help='Sequences are coding or noncoding. Must be one of: ' + ' '.join(coding_choices), choices=coding_choices, metavar='(non)coding')
-subparser_aln2meta.add_argument('cluster_rep', help='Name of sequence to be used as cluster representative. Must exactly match a sequence in aln_fasta file')
 subparser_aln2meta.add_argument('outprefix', help='Prefix of output filenames')
 subparser_aln2meta.set_defaults(func=ariba.tasks.aln2meta.run)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ fermilite_mod = Extension(
 setup(
     ext_modules=[minimap_mod, fermilite_mod],
     name='ariba',
-    version='2.2.0',
+    version='2.2.1',
     description='ARIBA: Antibiotic Resistance Identification By Assembly',
     packages = find_packages(),
     package_data={'ariba': ['test_run_data/*']},


### PR DESCRIPTION
aln2meta was broken because no need to give a cd-hit cluster representative. This fixes it.