### PR TITLE
bug fix summary when no samtools alt

### DIFF
--- a/ariba/summary_cluster_variant.py
+++ b/ariba/summary_cluster_variant.py
@@ -33,7 +33,7 @@ class SummaryClusterVariant:
 
     @classmethod
     def _get_het_percent(cls, data_dict):
-        if data_dict['gene'] == '1' or data_dict['ref_ctg_effect'] != 'SNP' or data_dict['smtls_alt_nt'] == '.' or ';' in data_dict['smtls_alt_nt']:
+        if data_dict['gene'] == '1' or data_dict['ref_ctg_effect'] != 'SNP' or data_dict['smtls_alt_nt'] == '.' or ';' in data_dict['smtls_alt_nt'] or data_dict['smtls_alt_depth'] == 'ND':
             return None
         else:
             nucleotides = [data_dict['ctg_nt']] + data_dict['smtls_alt_nt'].split(',')

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ fermilite_mod = Extension(
 setup(
     ext_modules=[minimap_mod, fermilite_mod],
     name='ariba',
-    version='2.2.2',
+    version='2.2.3',
     description='ARIBA: Antibiotic Resistance Identification By Assembly',
     packages = find_packages(),
     package_data={'ariba': ['test_run_data/*']},


### PR DESCRIPTION
Fixes a bug where in rare cases, there was no samtools call for a variant. Which means the assembly happened, and a variant was called between the assembly and the reference, but samtools had no depth. In the summary file, ARIBA reports ND. This fix handles the case when running ariba summary and ND is in the report file.