### PR TITLE
Newick rooting bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once the dependencies are installed, install ARIBA using pip:
 
 ARIBA also depends on several Python packages, all of which are available
 via pip, so the above command will get those automatically if they
-are not installed. The packages are dendropy >= 4.1.0,
+are not installed. The packages are dendropy >= 4.2.0,
 pyfastaq >= 3.12.0, pysam >= 0.9.1, and pymummer >= 0.10.1.
 
 Alternatively, you can download the latest release from this github repository,

--- a/ariba/summary.py
+++ b/ariba/summary.py
@@ -334,7 +334,7 @@ class Summary:
             pdm = dendropy.PhylogeneticDistanceMatrix.from_csv(src=f, delimiter='\t')
         upgma_tree = pdm.upgma_tree()
         with open(outfile, 'w') as f:
-            print(upgma_tree.as_string("newick").replace("'", ''), end='', file=f)
+            print(upgma_tree.as_string("newick", suppress_rooting=True).replace("'", ''), end='', file=f)
 
 
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     tests_require=['nose >= 1.3'],
     install_requires=[
         'BeautifulSoup4 >= 4.1.0',
-        'dendropy >= 4.1.0',
+        'dendropy >= 4.2.0',
         'pyfastaq >= 3.12.0',
         'pysam >= 0.9.1',
         'pymummer>=0.10.1',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ vcfcall_mod = Extension(
 setup(
     ext_modules=[minimap_mod, fermilite_mod, vcfcall_mod],
     name='ariba',
-    version='2.7.0',
+    version='2.7.1',
     description='ARIBA: Antibiotic Resistance Identification By Assembly',
     packages = find_packages(),
     package_data={'ariba': ['test_run_data/*']},


### PR DESCRIPTION
Bug introduced by moving from dendropy 4.1.0 to 4.2.0, where newick tree was defaulting to rooted, putting a '[&R] ' at the start of the tree file, breaking phandango.