### PR TITLE
Getref xfinder bitbucket

### DIFF
--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -208,17 +208,22 @@ class RefGenesGetter:
         tmpdir = outprefix + '.tmp.download'
         current_dir = os.getcwd()
 
-        try:
-            os.mkdir(tmpdir)
-            os.chdir(tmpdir)
-        except:
-            raise Error('Error mkdir/chdir ' + tmpdir)
+        if self.version =='old':
+            try:
+                os.mkdir(tmpdir)
+                os.chdir(tmpdir)
+            except:
+                raise Error('Error mkdir/chdir ' + tmpdir)
 
-        zipfile = 'resfinder.zip'
-        cmd = 'curl -X POST --data "folder=resfinder&filename=resfinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
-        print('Downloading data with:', cmd, sep='\n')
-        common.syscall(cmd)
-        common.syscall('unzip ' + zipfile)
+            zipfile = 'resfinder.zip'
+            cmd = 'curl -X POST --data "folder=resfinder&filename=resfinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
+            print('Downloading data with:', cmd, sep='\n')
+            common.syscall(cmd)
+            common.syscall('unzip ' + zipfile)
+        else:
+            RefGenesGetter._get_genetic_epi_database_from_bitbucket('resfinder', tmpdir, git_commit=self.version)
+            os.chdir(tmpdir)
+
 
         print('Combining downloaded fasta files...')
         fout_fa = pyfastaq.utils.open_file_write(final_fasta)
@@ -237,7 +242,7 @@ class RefGenesGetter:
                     except:
                         description = '.'
 
-                    # names are not unique across the files
+                    # names are not unique across the files
                     if seq.id in used_names:
                         used_names[seq.id] += 1
                         seq.id += '_' + str(used_names[seq.id])

--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -330,17 +330,21 @@ class RefGenesGetter:
         tmpdir = outprefix + '.tmp.download'
         current_dir = os.getcwd()
 
-        try:
-            os.mkdir(tmpdir)
-            os.chdir(tmpdir)
-        except:
-            raise Error('Error mkdir/chdir ' + tmpdir)
+        if self.version == 'old':
+            try:
+                os.mkdir(tmpdir)
+                os.chdir(tmpdir)
+            except:
+                raise Error('Error mkdir/chdir ' + tmpdir)
 
-        zipfile = 'plasmidfinder.zip'
-        cmd = 'curl -X POST --data "folder=plasmidfinder&filename=plasmidfinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
-        print('Downloading data with:', cmd, sep='\n')
-        common.syscall(cmd)
-        common.syscall('unzip ' + zipfile)
+            zipfile = 'plasmidfinder.zip'
+            cmd = 'curl -X POST --data "folder=plasmidfinder&filename=plasmidfinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
+            print('Downloading data with:', cmd, sep='\n')
+            common.syscall(cmd)
+            common.syscall('unzip ' + zipfile)
+        else:
+            RefGenesGetter._get_genetic_epi_database_from_bitbucket('plasmidfinder', tmpdir, git_commit=self.version)
+            os.chdir(tmpdir)
 
         print('Combining downloaded fasta files...')
         fout_fa = pyfastaq.utils.open_file_write(final_fasta)
@@ -479,17 +483,21 @@ class RefGenesGetter:
         tmpdir = outprefix + '.tmp.download'
         current_dir = os.getcwd()
 
-        try:
-            os.mkdir(tmpdir)
-            os.chdir(tmpdir)
-        except:
-            raise Error('Error mkdir/chdir ' + tmpdir)
+        if self.version == 'old':
+            try:
+                os.mkdir(tmpdir)
+                os.chdir(tmpdir)
+            except:
+                raise Error('Error mkdir/chdir ' + tmpdir)
 
-        zipfile = 'plasmidfinder.zip'
-        cmd = 'curl -X POST --data "folder=virulencefinder&filename=virulencefinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
-        print('Downloading data with:', cmd, sep='\n')
-        common.syscall(cmd)
-        common.syscall('unzip ' + zipfile)
+            zipfile = 'plasmidfinder.zip'
+            cmd = 'curl -X POST --data "folder=virulencefinder&filename=virulencefinder.zip" -o ' + zipfile + ' https://cge.cbs.dtu.dk/cge/download_data.php'
+            print('Downloading data with:', cmd, sep='\n')
+            common.syscall(cmd)
+            common.syscall('unzip ' + zipfile)
+        else:
+            RefGenesGetter._get_genetic_epi_database_from_bitbucket('plasmidfinder', tmpdir, git_commit=self.version)
+            os.chdir(tmpdir)
 
         print('Combining downloaded fasta files...')
         fout_fa = pyfastaq.utils.open_file_write(final_fasta)

--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -7,6 +7,7 @@ import tarfile
 import pyfastaq
 import time
 import json
+import subprocess
 import sys
 from ariba import common, card_record, vfdb_parser, megares_data_finder, megares_zip_parser
 
@@ -185,6 +186,19 @@ class RefGenesGetter:
         print('If you use this downloaded data, please cite:')
         print('"The Comprehensive Antibiotic Resistance Database", McArthur et al 2013, PMID: 23650175')
         print('and in your methods say that version', self.version, 'of the database was used')
+
+
+    @classmethod
+    def _get_genetic_epi_database_from_bitbucket(cls, db_name, outdir, git_commit=None):
+        assert db_name in {'plasmidfinder', 'resfinder', 'virulence_finder'}
+        cmd = 'git clone ' + 'https://bitbucket.org/genomicepidemiology/' + db_name + '_db.git ' + outdir
+        common.syscall(cmd)
+
+        if git_commit is not None:
+            common.syscall('cd ' + outdir + ' && git checkout ' + git_commit)
+
+        print('Using this git commit for ' + db_name + ' database:')
+        subprocess.check_call('cd ' + outdir + ' && git log -n 1', shell=True)
 
 
     def _get_from_resfinder(self, outprefix):

--- a/scripts/ariba
+++ b/scripts/ariba
@@ -62,7 +62,7 @@ subparser_getref = subparsers.add_parser(
     description='Download reference data from one of a few supported public resources',
 )
 subparser_getref.add_argument('--debug', action='store_true', help='Do not delete temporary downloaded files')
-subparser_getref.add_argument('--version', help='Version of reference data to download. If not used, gets the latest version. Only applies to card and megares')
+subparser_getref.add_argument('--version', help='Version of reference data to download. If not used, gets the latest version. Only applies to card, megares, resfinder. For resfinder: default is to get latest from bitbucket, or supply git commit hash to get a specific version from bitbucket, or use "old " to get from old website.')
 subparser_getref.add_argument('db', help='Database to download. Must be one of: ' + ' '.join(allowed_dbs), choices=allowed_dbs, metavar="DB name")
 subparser_getref.add_argument('outprefix', help='Prefix of output filenames')
 subparser_getref.set_defaults(func=ariba.tasks.getref.run)

--- a/scripts/ariba
+++ b/scripts/ariba
@@ -62,7 +62,7 @@ subparser_getref = subparsers.add_parser(
     description='Download reference data from one of a few supported public resources',
 )
 subparser_getref.add_argument('--debug', action='store_true', help='Do not delete temporary downloaded files')
-subparser_getref.add_argument('--version', help='Version of reference data to download. If not used, gets the latest version. Only applies to card, megares, resfinder. For resfinder: default is to get latest from bitbucket, or supply git commit hash to get a specific version from bitbucket, or use "old " to get from old website.')
+subparser_getref.add_argument('--version', help='Version of reference data to download. If not used, gets the latest version. Only applies to card, megares, plasmidfinder, resfinder, virulencefinder. For plasmid/res/virulencefinder: default is to get latest from bitbucket - supply git commit hash to get a specific version from bitbucket, or use "old " to get from old website.')
 subparser_getref.add_argument('db', help='Database to download. Must be one of: ' + ' '.join(allowed_dbs), choices=allowed_dbs, metavar="DB name")
 subparser_getref.add_argument('outprefix', help='Prefix of output filenames')
 subparser_getref.set_defaults(func=ariba.tasks.getref.run)


### PR DESCRIPTION
plasmidfinder, resfinder, and virulencefinder all moved to bitbucket. This changes the behaviour of `getref` to get the tip of master from bitbucket. Alternatively, the user can supply a git commit hash, or "old" to get the old datasets. See issues #216 and #218. 