### PR TITLE
Get srst2_argannot latest version r2 by default

### DIFF
--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -381,8 +381,13 @@ class RefGenesGetter:
 
 
     def _get_from_srst2_argannot(self, outprefix):
-        srst2_version = '0.2.0'
-        srst2_url = 'https://github.com/katholt/srst2/raw/v' + srst2_version + '/data/ARGannot.r1.fasta'
+        if self.version is None:
+            self.version = 'r2'
+        if self.version not in {'r1', 'r2'}:
+            raise Error('srst2_argannot version must be r1 or r2. Got this: ' + self.version)
+
+        version_string = '.r1' if self.version == 'r1' else '_r2'
+        srst2_url = 'https://raw.githubusercontent.com/katholt/srst2/master/data/ARGannot' + version_string + '.fasta'
         srst2_fa = outprefix + '.original.fa'
         command = 'wget -O ' + srst2_fa + ' ' + srst2_url
         common.syscall(command, verbose=True)
@@ -413,7 +418,9 @@ class RefGenesGetter:
         print('If you use this downloaded data, please cite:')
         print('"SRST2: Rapid genomic surveillance for public health and hospital microbiology labs",\nInouye et al 2014, Genome Medicine, PMID: 25422674\n')
         print(argannot_ref)
-        print('and in your methods say that the ARG-ANNOT sequences were used from version', srst2_version, 'of SRST2.')
+        # Use to also output the version of SRST2 here, but the r2 version of their
+        # fasta file was made after SRST2 release 0.2.0. At the time of writing this,
+        # 0.2.0 is the latest release, ie r2 isn't in an SRST2 release.
 
 
     def _get_from_vfdb_core(self, outprefix):

--- a/scripts/ariba
+++ b/scripts/ariba
@@ -62,7 +62,7 @@ subparser_getref = subparsers.add_parser(
     description='Download reference data from one of a few supported public resources',
 )
 subparser_getref.add_argument('--debug', action='store_true', help='Do not delete temporary downloaded files')
-subparser_getref.add_argument('--version', help='Version of reference data to download. If not used, gets the latest version. Only applies to card, megares, plasmidfinder, resfinder, virulencefinder. For plasmid/res/virulencefinder: default is to get latest from bitbucket - supply git commit hash to get a specific version from bitbucket, or use "old " to get from old website.')
+subparser_getref.add_argument('--version', help='Version of reference data to download. If not used, gets the latest version. Applies to: card, megares, plasmidfinder, resfinder, srst2_argannot, virulencefinder. For plasmid/res/virulencefinder: default is to get latest from bitbucket - supply git commit hash to get a specific version from bitbucket, or use "old " to get from old website. For srst2_argannot: default is latest version r2, use r1 to get the older version')
 subparser_getref.add_argument('db', help='Database to download. Must be one of: ' + ' '.join(allowed_dbs), choices=allowed_dbs, metavar="DB name")
 subparser_getref.add_argument('outprefix', help='Prefix of output filenames')
 subparser_getref.set_defaults(func=ariba.tasks.getref.run)


### PR DESCRIPTION
Get srst2 argannot version r2 by default. Use `--version r1` to get the old version. Issue #217 