### PR TITLE
Do not use rmtree

### DIFF
--- a/ariba/assembly.py
+++ b/ariba/assembly.py
@@ -1,10 +1,9 @@
 import os
 import sys
-import shutil
 import pyfastaq
 import pymummer
 import fermilite_ariba
-from ariba import common, faidx, mapping, bam_parse, external_progs, ref_seq_chooser
+from ariba import common, mapping, bam_parse, external_progs, ref_seq_chooser
 import shlex
 
 class Error (Exception): pass
@@ -197,7 +196,7 @@ class Assembly:
                             self.assembled_ok = True
             if self.clean:
                 print('Deleting assembly directory', self.assembler_dir, file=self.log_fh)
-                shutil.rmtree(self.assembler_dir,ignore_errors=True)
+                common.rmtree(self.assembler_dir)
         finally:
             os.chdir(cwd)
 

--- a/ariba/cdhit.py
+++ b/ariba/cdhit.py
@@ -1,5 +1,4 @@
 import tempfile
-import shutil
 import sys
 import os
 import pyfastaq
@@ -152,6 +151,6 @@ class Runner:
 
         common.syscall(cmd, verbose=self.verbose)
         clusters = self._get_clusters_from_bak_file(cluster_info_outfile, self.min_cluster_number)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
         return clusters
 

--- a/ariba/cluster.py
+++ b/ariba/cluster.py
@@ -4,10 +4,9 @@ import os
 import atexit
 import random
 import math
-import shutil
 import sys
 import pyfastaq
-from ariba import assembly, assembly_compare, assembly_variants, external_progs, flag, mapping, report, samtools_variants
+from ariba import assembly, assembly_compare, assembly_variants, common, external_progs, flag, mapping, report, samtools_variants
 
 class Error (Exception): pass
 
@@ -369,7 +368,7 @@ class Cluster:
             self._clean_file(self.reads_for_assembly2)
             if self.clean:
                 print('Deleting Assembly directory', self.assembly_dir, file=self.log_fh, flush=True)
-                shutil.rmtree(self.assembly_dir,ignore_errors=True)
+                common.rmtree(self.assembly_dir)
 
 
         if self.assembled_ok and self.assembly.ref_seq_name is not None:

--- a/ariba/clusters.py
+++ b/ariba/clusters.py
@@ -6,7 +6,6 @@ import tempfile
 import pickle
 import itertools
 import sys
-import shutil
 import multiprocessing
 import pyfastaq
 import minimap_ariba
@@ -42,7 +41,7 @@ def _run_cluster(obj, verbose, clean, fails_dir, remaining_clusters, remaining_c
             print('Deleting cluster dir', obj.root_dir, flush=True)
         if os.path.exists(obj.root_dir):
             try:
-                shutil.rmtree(obj.root_dir)
+                common.rmtree(obj.root_dir)
             except:
                 pass
 
@@ -557,7 +556,7 @@ class Clusters:
 
     def _clean(self):
         if self.clean:
-            shutil.rmtree(self.fails_dir,ignore_errors=True)
+            common.rmtree(self.fails_dir)
 
             try:
                 self.tmp_dir_obj.cleanup()
@@ -566,7 +565,7 @@ class Clusters:
 
             if self.verbose:
                 print('Deleting Logs directory', self.logs_dir)
-            shutil.rmtree(self.logs_dir,ignore_errors=True)
+            common.rmtree(self.logs_dir)
 
             try:
                 if self.verbose:

--- a/ariba/common.py
+++ b/ariba/common.py
@@ -73,3 +73,9 @@ def download_file(url, outfile, max_attempts=3, sleep_time=2, verbose=False):
     if verbose:
         print(' done', flush=True)
 
+
+def rmtree(input_dir):
+    '''Does rm -r on input_dir. Meant to replace shutil.rmtree,
+    which seems to be causing issues with files not getting deleted
+    and the directory non-empty afterwards'''
+    syscall('rm -r ' + input_dir)

--- a/ariba/common.py
+++ b/ariba/common.py
@@ -78,4 +78,4 @@ def rmtree(input_dir):
     '''Does rm -r on input_dir. Meant to replace shutil.rmtree,
     which seems to be causing issues with files not getting deleted
     and the directory non-empty afterwards'''
-    syscall('rm -r ' + input_dir)
+    syscall('rm -rf ' + input_dir)

--- a/ariba/megares_zip_parser.py
+++ b/ariba/megares_zip_parser.py
@@ -2,7 +2,6 @@ import os
 import sys
 import csv
 import zipfile
-import shutil
 import pyfastaq
 from ariba import common
 
@@ -39,7 +38,7 @@ class MegaresZipParser:
             zfile.extract(member, path=outdir)
 
         if None in original_files.values():
-            shutil.rmtree(outdir)
+            common.rmtree(outdir)
             raise Error('Error. Not all expected files found in downloaded megares zipfile. ' + str(original_files))
 
         return original_files
@@ -114,6 +113,6 @@ class MegaresZipParser:
         sequences = {}
         pyfastaq.tasks.file_to_dict(os.path.join(tmpdir, original_files['fasta']), sequences)
         MegaresZipParser._write_files(self.outprefix, sequences, annotation_data, header_data)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
         os.unlink(self.zip_file)
 

--- a/ariba/mic_plotter.py
+++ b/ariba/mic_plotter.py
@@ -12,7 +12,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.cm as cmx
 import math
 import pyfastaq
-from ariba import common, reference_data
+from ariba import reference_data
 
 class Error (Exception): pass
 

--- a/ariba/mlst_reporter.py
+++ b/ariba/mlst_reporter.py
@@ -1,4 +1,3 @@
-import os
 import pyfastaq
 from ariba import mlst_profile, summary_sample
 

--- a/ariba/pubmlst_getter.py
+++ b/ariba/pubmlst_getter.py
@@ -2,10 +2,10 @@ import tempfile
 import re
 import time
 import os
-import shutil
 import urllib.request
 import xml.etree.ElementTree as ET
 import pyfastaq
+from ariba import common
 
 class Error (Exception): pass
 
@@ -29,7 +29,7 @@ class PubmlstGetter:
         xml_tree = ET.parse(xml_file)
 
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
 
         return xml_tree
 

--- a/ariba/read_filter.py
+++ b/ariba/read_filter.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 
 from ariba import common, external_progs
 
@@ -79,5 +78,5 @@ class ReadFilter:
             wanted_ids=wanted_read_ids
         )
 
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
         return total_reads, total_bases

--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -2,10 +2,8 @@ class Error (Exception): pass
 
 import os
 import re
-import shutil
 import tarfile
 import pyfastaq
-import time
 import json
 import subprocess
 import sys
@@ -177,7 +175,7 @@ class RefGenesGetter:
         pyfastaq.utils.close(f_out_log)
         os.chdir(current_dir)
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
 
         print('Extracted data and written ARIBA input files\n')
         print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
@@ -257,7 +255,7 @@ class RefGenesGetter:
         print('\nFinished combining files\n')
         os.chdir(current_dir)
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
         print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
         print('You can use them with ARIBA like this:')
         print('ariba prepareref -f', final_fasta, '-m', final_tsv, 'output_directory\n')
@@ -300,7 +298,7 @@ class RefGenesGetter:
         pyfastaq.utils.close(f_out_tsv)
         pyfastaq.utils.close(f_out_fa)
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
 
         print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
         print('You can use them with ARIBA like this:')
@@ -372,7 +370,7 @@ class RefGenesGetter:
         print('\nFinished combining files\n')
         os.chdir(current_dir)
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
         print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
         print('You can use them with ARIBA like this:')
         print('ariba prepareref -f', final_fasta, '-m', final_tsv, 'output_directory\n')
@@ -446,7 +444,7 @@ class RefGenesGetter:
         vparser = vfdb_parser.VfdbParser(zipfile, outprefix)
         vparser.run()
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
         print('done')
         final_fasta = outprefix + '.fa'
         final_tsv = outprefix + '.tsv'
@@ -534,7 +532,7 @@ class RefGenesGetter:
         print('\nFinished combining files\n')
         os.chdir(current_dir)
         if not self.debug:
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
         print('Finished. Final files are:', final_fasta, final_tsv, sep='\n\t', end='\n\n')
         print('You can use them with ARIBA like this:')
         print('ariba prepareref -f', final_fasta, '-m', final_tsv, 'output_directory\n')

--- a/ariba/ref_preparer.py
+++ b/ariba/ref_preparer.py
@@ -1,9 +1,8 @@
 import sys
 import os
-import shutil
 import pickle
 import pyfastaq
-from ariba import reference_data
+from ariba import common, reference_data
 
 class Error (Exception): pass
 
@@ -140,7 +139,7 @@ class RefPreparer:
         original_dir = os.getcwd()
 
         if self.force and os.path.exists(outdir):
-            shutil.rmtree(outdir)
+            common.rmtree(outdir)
 
         if os.path.exists(outdir):
             raise Error('Error! Output directory ' + outdir + ' already exists. Cannot continue')

--- a/ariba/ref_seq_chooser.py
+++ b/ariba/ref_seq_chooser.py
@@ -3,7 +3,7 @@ import copy
 import os
 import pymummer
 import pyfastaq
-import shutil
+from ariba import common
 
 class Error (Exception): pass
 
@@ -147,7 +147,7 @@ class RefSeqChooser:
             maxmatch=True,
         ).run()
         nucmer_matches = RefSeqChooser._load_nucmer_coords_file(coords_file, log_fh=log_fh)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
         if len(nucmer_matches) == 0:
             return None, {}
@@ -172,7 +172,7 @@ class RefSeqChooser:
 
         print('Checking for a better match to a ref sequence outside the cluster', file=self.log_fh)
         best_hit_from_all_seqs, not_needed = RefSeqChooser._closest_nucmer_match_between_fastas(self.all_refs_fasta, pieces_fasta_file, self.log_fh, self.nucmer_min_id, self.nucmer_min_len, self.nucmer_breaklen, True, False)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
         self.closest_ref_from_all_refs = best_hit_from_all_seqs.ref_name
         if self.closest_ref_from_all_refs is None:
             return

--- a/ariba/report_flag_expander.py
+++ b/ariba/report_flag_expander.py
@@ -1,6 +1,3 @@
-import copy
-import sys
-
 import pyfastaq
 
 from ariba import flag

--- a/ariba/summary_cluster.py
+++ b/ariba/summary_cluster.py
@@ -1,4 +1,3 @@
-import sys
 from ariba import flag, report, summary_cluster_variant
 
 class Error (Exception): pass

--- a/ariba/tests/assembly_test.py
+++ b/ariba/tests/assembly_test.py
@@ -1,10 +1,8 @@
 import unittest
-import sys
 import os
-import shutil
 import filecmp
 import pyfastaq
-from ariba import assembly
+from ariba import assembly, common
 from ariba import external_progs
 
 modules_dir = os.path.dirname(os.path.abspath(assembly.__file__))
@@ -56,7 +54,7 @@ class TestAssembly(unittest.TestCase):
         tmp_log_fh.close()
         self.assertTrue(filecmp.cmp(expected_log, tmp_log, shallow=False))
         self.assertTrue(filecmp.cmp(expected_fa, os.path.join(tmp_dir, 'debug_all_contigs.fa'), shallow=False))
-        shutil.rmtree(tmp_dir)
+        common.rmtree(tmp_dir)
         os.unlink(tmp_log)
 
 
@@ -75,7 +73,7 @@ class TestAssembly(unittest.TestCase):
         tmp_log_fh.close()
         self.assertTrue(filecmp.cmp(expected_log, tmp_log, shallow=False))
         self.assertFalse(os.path.exists(os.path.join(tmp_dir, 'contigs.fa')))
-        shutil.rmtree(tmp_dir)
+        common.rmtree(tmp_dir)
         os.unlink(tmp_log)
 
 
@@ -120,7 +118,7 @@ class TestAssembly(unittest.TestCase):
         tmp_log = 'tmp.test_assemble_with_spades.log'
         with open(tmp_log, 'w') as tmp_log_fh:
             print('First line', file=tmp_log_fh)
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+            common.rmtree(tmp_dir)
             #using spades_options=" --only-assembler" because error correction cannot determine quality offset on this
             #artificial dataset
             a = assembly.Assembly(reads1, reads2, 'not needed', 'not needed', tmp_dir, 'not_needed_for_this_test.fa',
@@ -128,7 +126,7 @@ class TestAssembly(unittest.TestCase):
                                   assembler="spades", spades_options=" --only-assembler")
             a._assemble_with_spades()
         self.assertTrue(a.assembled_ok)
-        shutil.rmtree(tmp_dir,ignore_errors=True)
+        common.rmtree(tmp_dir)
         os.unlink(tmp_log)
 
     @unittest.skipUnless(extern_progs.exe('spades'), "Spades assembler is optional and is not configured")
@@ -140,11 +138,11 @@ class TestAssembly(unittest.TestCase):
         tmp_log = 'tmp.test_assemble_with_spades_fail.log'
         with open(tmp_log, 'w') as tmp_log_fh:
             print('First line', file=tmp_log_fh)
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+            common.rmtree(tmp_dir)
             a = assembly.Assembly(reads1, reads2, 'not needed', 'not needed', tmp_dir, 'not_needed_for_this_test.fa',
                                   'not_needed_for_this_test.bam', tmp_log_fh, 'not needed',
                                   assembler="spades", spades_options=" --only-assembler")
             a._assemble_with_spades()
         self.assertFalse(a.assembled_ok)
-        shutil.rmtree(tmp_dir,ignore_errors=True)
+        common.rmtree(tmp_dir)
         os.unlink(tmp_log)

--- a/ariba/tests/cluster_test.py
+++ b/ariba/tests/cluster_test.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import shutil
 import filecmp
-from ariba import cluster, reference_data
+from ariba import cluster, common, reference_data
 
 modules_dir = os.path.dirname(os.path.abspath(cluster.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
@@ -23,7 +23,7 @@ def clean_cluster_dir(d, exclude=None):
         if name not in keep:
             full_path = os.path.join(d, name)
             if os.path.isdir(full_path):
-                shutil.rmtree(full_path)
+                common.rmtree(full_path)
             else:
                 os.unlink(full_path)
 
@@ -43,11 +43,11 @@ class TestCluster(unittest.TestCase):
         dirs = [os.path.join(data_dir, d) for d in dirs]
         for d in dirs:
             tmpdir = 'tmp.cluster_test_init_fail_files_missing'
-            shutil.rmtree(tmpdir,ignore_errors=True)
+            common.rmtree(tmpdir)
             shutil.copytree(d, tmpdir)
             with self.assertRaises(cluster.Error):
                 cluster.Cluster(tmpdir, 'name', refdata=refdata, total_reads=42, total_reads_bases=4242)
-            shutil.rmtree(tmpdir)
+            common.rmtree(tmpdir)
 
 
     def test_number_of_reads_for_assembly(self):
@@ -101,7 +101,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_no_reads_after_filtering.in.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.test_full_run_no_reads_after_filtering'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_no_reads_after_filtering'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=0, total_reads_bases=0)
@@ -111,7 +111,7 @@ class TestCluster(unittest.TestCase):
         self.assertEqual([expected], c.report_lines)
         self.assertFalse(c.status_flag.has('ref_seq_choose_fail'))
         self.assertTrue(c.status_flag.has('assembly_fail'))
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_choose_ref_fail(self):
@@ -120,7 +120,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_choose_ref_fail.in.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.test_full_run_choose_ref_fail'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_choose_ref_fail'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=2, total_reads_bases=108)
@@ -130,7 +130,7 @@ class TestCluster(unittest.TestCase):
         self.assertEqual([expected], c.report_lines)
         self.assertTrue(c.status_flag.has('ref_seq_choose_fail'))
         self.assertFalse(c.status_flag.has('assembly_fail'))
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ref_not_in_cluster(self):
@@ -140,7 +140,7 @@ class TestCluster(unittest.TestCase):
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.test_full_run_ref_not_in_cluster'
         all_refs_fa =  os.path.join(data_dir, 'cluster_test_full_run_ref_not_in_cluster.all_refs.fa')
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ref_not_in_cluster'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=72, total_reads_bases=3600, all_ref_seqs_fasta=all_refs_fa)
@@ -150,7 +150,7 @@ class TestCluster(unittest.TestCase):
         self.assertEqual([expected], c.report_lines)
         self.assertTrue(c.status_flag.has('ref_seq_choose_fail'))
         self.assertFalse(c.status_flag.has('assembly_fail'))
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_assembly_fail(self):
@@ -159,7 +159,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_assembly_fail.in.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.test_full_run_assembly_fail'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_assembly_fail'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=4, total_reads_bases=304)
@@ -169,7 +169,7 @@ class TestCluster(unittest.TestCase):
         self.assertEqual([expected], c.report_lines)
         self.assertFalse(c.status_flag.has('ref_seq_choose_fail'))
         self.assertTrue(c.status_flag.has('assembly_fail'))
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ok_non_coding(self):
@@ -178,7 +178,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_ok_non_coding.metadata.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.test_full_run_ok_non_coding'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ok_non_coding'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=72, total_reads_bases=3600)
@@ -195,7 +195,7 @@ class TestCluster(unittest.TestCase):
         ]
 
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ok_presence_absence(self):
@@ -204,7 +204,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_ok_presence_absence.metadata.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_presence_absence'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ok_presence_absence'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=64, total_reads_bases=3200)
@@ -218,7 +218,7 @@ class TestCluster(unittest.TestCase):
         ]
 
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ok_variants_only_variant_not_present(self):
@@ -227,7 +227,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_ok_variants_only.not_present.metadata.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_variants_only.not_present'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ok_variants_only'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=66, total_reads_bases=3300)
@@ -236,7 +236,7 @@ class TestCluster(unittest.TestCase):
             'variants_only1\tvariants_only1\t1\t1\t27\t66\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t215\t15.3\t1\tSNP\tp\tR3S\t0\t.\t.\t7\t9\tCGC\t65\t67\tCGC\t18;18;19\tC;G;C\t18;18;19\tvariants_only1:1:1:R3S:.:Ref and assembly have wild type, so do not report\tGeneric description of variants_only1'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ok_variants_only_variant_not_present_always_report(self):
@@ -245,7 +245,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_varonly.not_present.always_report.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_full_run_varonly.not_present.always_report'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ok_variants_only'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=66, total_reads_bases=3300)
@@ -254,7 +254,7 @@ class TestCluster(unittest.TestCase):
             'variants_only1\tvariants_only1\t1\t1\t27\t66\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t215\t15.3\t1\tSNP\tp\tR3S\t0\t.\t.\t7\t9\tCGC\t65\t67\tCGC\t18;18;19\tC;G;C\t18;18;19\tvariants_only1:1:1:R3S:.:Ref and assembly have wild type, but always report anyway\tGeneric description of variants_only1'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ok_variants_only_variant_is_present(self):
@@ -263,7 +263,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_ok_variants_only.present.metadata.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_variants_only.present'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ok_variants_only'), tmpdir)
 
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=66, total_reads_bases=3300)
@@ -274,7 +274,7 @@ class TestCluster(unittest.TestCase):
             'variants_only1\tvariants_only1\t1\t1\t27\t66\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t215\t15.3\t1\tSNP\tp\tI5A\t1\t.\t.\t13\t15\tGCG\t71\t73\tGCG\t17;17;17\tG;C;G\t17;17;17\tvariants_only1:1:1:I5A:.:Ref and reads have variant so report\tGeneric description of variants_only1',
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_ok_gene_start_mismatch(self):
@@ -283,7 +283,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_ok_gene_start_mismatch.metadata.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_gene_start_mismatch'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_ok_gene_start_mismatch'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=112, total_reads_bases=1080)
         c.run()
@@ -291,7 +291,7 @@ class TestCluster(unittest.TestCase):
             'gene\tgene\t1\t0\t27\t112\tcluster_name\t96\t96\t100.0\tcluster_name.l6.c30.ctg.1\t362\t27.8\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\tGeneric description of gene'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_presabs_gene(self):
@@ -300,7 +300,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_presabs_gene.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_samtools_snp_pres_abs_gene'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_presabs_gene'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -308,7 +308,7 @@ class TestCluster(unittest.TestCase):
             'ref_gene\tref_gene\t1\t0\t155\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t0\tHET\t.\t.\t.\tG18A\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\t.\tGeneric description of ref_gene'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_varonly_gene_2(self):
@@ -319,7 +319,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_gene_2.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_full_run_smtls_snp_varonly_gene_2'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_gene_2'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -327,7 +327,7 @@ class TestCluster(unittest.TestCase):
             'ref_gene\tref_gene\t1\t1\t155\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t0\tHET\t.\t.\t.\tG18A\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\t.\tGeneric description of ref_gene'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_known_smtls_snp_presabs_gene(self):
@@ -336,7 +336,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_known_smtls_snp_presabs_gene.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_samtools_snp_known_position_pres_abs_gene'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_known_smtls_snp_presabs_gene'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -347,7 +347,7 @@ class TestCluster(unittest.TestCase):
             'ref_gene\tref_gene\t1\t0\t155\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tp\tM6I\t0\t.\t.\t16\t18\tATG\t135\t137\tATG\t65;64;63\tA;T;G,A\t65;64;32,31\tref_gene:1:0:M6I:.:Description of M6I snp\t.'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_varonly_gene_no_snp(self):
@@ -356,7 +356,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_gene_no_snp.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_smtls_snp_varonly_gene_no_snp'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_gene_no_snp'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -367,7 +367,7 @@ class TestCluster(unittest.TestCase):
             'ref_gene\tref_gene\t1\t1\t155\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tp\tM6I\t0\t.\t.\t16\t18\tATG\t135\t137\tATG\t65;64;63\tA;T;G,A\t65;64;32,31\tref_gene:1:1:M6I:.:Description of M6I snp\t.'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_varonly_gene(self):
@@ -376,7 +376,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_gene.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_samtools_snp_known_position_var_only_gene_does_have_var'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_gene'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -387,7 +387,7 @@ class TestCluster(unittest.TestCase):
             'ref_gene\tref_gene\t1\t1\t155\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tp\tI6M\t1\t.\t.\t16\t18\tATG\t135\t137\tATG\t65;64;63\tA;T;G,A\t65;64;32,31\tref_gene:1:1:I6M:.:Description of I6M snp\t.'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_presabs_nonc(self):
@@ -396,7 +396,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_presabs_nonc.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_smtls_snp_presabs_nonc'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_presabs_nonc'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -404,7 +404,7 @@ class TestCluster(unittest.TestCase):
             'ref_seq\tref_seq\t0\t0\t147\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t0\tHET\t.\t.\t.\tG18A\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\t.\tGeneric description of ref_seq'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_known_snp_presabs_nonc(self):
@@ -413,7 +413,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_known_snp_presabs_nonc.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_smtls_known_snp_presabs_nonc'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_known_snp_presabs_nonc'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -421,7 +421,7 @@ class TestCluster(unittest.TestCase):
             'ref_seq\tref_seq\t0\t0\t147\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tn\tG18A\t0\t.\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\tref_seq:0:0:G18A:.:Description of G18A\tGeneric description of ref_seq'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_varonly_nonc(self):
@@ -430,7 +430,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_nonc.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_full_run_smtls_snp_varonly_nonc'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_nonc'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -438,7 +438,7 @@ class TestCluster(unittest.TestCase):
             'ref_seq\tref_seq\t0\t1\t147\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t0\tHET\t.\t.\t.\tG18A\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\t.\tGeneric description of ref_seq'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_known_smtls_snp_presabs_nonc(self):
@@ -447,7 +447,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_known_smtls_snp_presabs_nonc.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_samtools_snp_known_position_pres_abs_noncoding'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_known_smtls_snp_presabs_nonc'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -458,7 +458,7 @@ class TestCluster(unittest.TestCase):
             'ref_seq\tref_seq\t0\t0\t147\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tn\tG18A\t0\t.\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\tref_seq:0:0:G18A:.:Description of G18A snp\t.'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_smtls_snp_varonly_nonc_no_snp(self):
@@ -467,7 +467,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_nonc_no_snp.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_samtools_snp_known_position_var_only_noncoding'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_full_run_smtls_snp_varonly_nonc_no_snp'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -478,7 +478,7 @@ class TestCluster(unittest.TestCase):
             'ref_seq\tref_seq\t0\t1\t147\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tn\tG18A\t0\t.\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\tref_seq:0:1:G18A:.:Description of G18A snp\t.'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_cluster_test_full_run_smtls_snp_varonly_nonc(self):
@@ -487,7 +487,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_smtls_snp_varonly_nonc.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_ok_samtools_snp_known_position_var_only_noncoding'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_smtls_snp_varonly_nonc'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=148, total_reads_bases=13320)
         c.run()
@@ -498,7 +498,7 @@ class TestCluster(unittest.TestCase):
             'ref_seq\tref_seq\t0\t1\t147\t148\tcluster_name\t96\t96\t100.0\tcluster_name.l15.c30.ctg.1\t335\t39.8\t1\tSNP\tn\tA18G\t1\t.\t.\t18\t18\tG\t137\t137\tG\t63\tG,A\t32,31\tref_seq:0:1:A18G:.:Description of A18G snp\t.'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_partial_assembly(self):
@@ -507,7 +507,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_partial_asmbly.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_partial_assembly'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_partial_asmbly'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=278, total_reads_bases=15020)
         c.run()
@@ -516,7 +516,7 @@ class TestCluster(unittest.TestCase):
             'presence_absence1\tpresence_absence1\t1\t0\t19\t278\tcluster_name\t96\t77\t100.0\tcluster_name.l15.c17.ctg.1\t949\t20.5\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\t.\tGeneric description of presence_absence1'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_multiple_vars_in_codon(self):
@@ -525,7 +525,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_multiple_vars.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_run_multiple_vars'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_multiple_vars'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=292, total_reads_bases=20900)
         c.run()
@@ -535,7 +535,7 @@ class TestCluster(unittest.TestCase):
             'presence_absence1\tpresence_absence1\t1\t0\t539\t292\tcluster_name\t96\t96\t96.91\tcluster_name.l15.c30.ctg.1\t1074\t20.4\t0\t.\tp\t.\t0\tA10fs\tFSHIFT\t28\t28\tG\t491\t491\tG\t26\tG\t26\t.\tGeneric description of presence_absence1',
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_delete_codon(self):
@@ -544,7 +544,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_delete_codon.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_delete_codon'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_delete_codon'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=292, total_reads_bases=20900)
         c.run()
@@ -553,7 +553,7 @@ class TestCluster(unittest.TestCase):
             'presence_absence1\tpresence_absence1\t1\t0\t539\t292\tcluster_name\t117\t117\t92.31\tcluster_name.l15.c30.ctg.1\t1104\t20.0\t0\t.\tp\t.\t0\tR25_A26del\tDEL\t73\t73\tA\t553\t553\tA\t27\tA\t27\t.\tGeneric description of presence_absence1',
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)
 
 
     def test_full_run_insert_codon(self):
@@ -562,7 +562,7 @@ class TestCluster(unittest.TestCase):
         tsv_in = os.path.join(data_dir, 'cluster_test_full_run_insert_codon.tsv')
         refdata = reference_data.ReferenceData([fasta_in], [tsv_in])
         tmpdir = 'tmp.cluster_test_full_insert_codon'
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        common.rmtree(tmpdir)
         shutil.copytree(os.path.join(data_dir, 'cluster_test_full_run_insert_codon'), tmpdir)
         c = cluster.Cluster(tmpdir, 'cluster_name', refdata, total_reads=292, total_reads_bases=20900)
         c.run()
@@ -571,4 +571,4 @@ class TestCluster(unittest.TestCase):
             'presence_absence1\tpresence_absence1\t1\t0\t539\t292\tcluster_name\t108\t108\t92.31\tcluster_name.l15.c30.ctg.1\t1115\t19.9\t0\t.\tp\t.\t0\tS25_M26insELI\tINS\t73\t73\tA\t554\t554\tG\t24\tG\t24\t.\tGeneric description of presence_absence1'
         ]
         self.assertEqual(expected, c.report_lines)
-        shutil.rmtree(tmpdir)
+        common.rmtree(tmpdir)

--- a/ariba/tests/clusters_test.py
+++ b/ariba/tests/clusters_test.py
@@ -4,7 +4,7 @@ import os
 import pickle
 import pyfastaq
 import filecmp
-from ariba import clusters, external_progs, histogram, sequence_metadata
+from ariba import clusters, common, external_progs, histogram, sequence_metadata
 
 modules_dir = os.path.dirname(os.path.abspath(clusters.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
@@ -37,8 +37,8 @@ class TestClusters(unittest.TestCase):
 
 
     def tearDown(self):
-        shutil.rmtree(self.cluster_dir)
-        shutil.rmtree(self.refdata_dir)
+        common.rmtree(self.cluster_dir)
+        common.rmtree(self.refdata_dir)
 
 
     def test_load_reference_data_info_file(self):

--- a/ariba/tests/common_test.py
+++ b/ariba/tests/common_test.py
@@ -20,3 +20,17 @@ class TestCommon(unittest.TestCase):
         common.cat_files(infiles, tmp_out)
         self.assertTrue(filecmp.cmp(expected, tmp_out, shallow=False))
         os.unlink(tmp_out)
+
+
+    def test_rmtree(self):
+        '''test rmtree'''
+        tmp_dir = 'tmp.rmtree'
+        os.mkdir(tmp_dir)
+        with open (os.path.join(tmp_dir, 'foo'), 'w') as f:
+            pass
+
+        self.assertTrue(os.path.exists(tmp_dir))
+        common.rmtree(tmp_dir)
+        self.assertFalse(os.path.exists(tmp_dir))
+
+

--- a/ariba/tests/megares_zip_parser_test.py
+++ b/ariba/tests/megares_zip_parser_test.py
@@ -1,10 +1,8 @@
 import unittest
-import copy
-import shutil
 import filecmp
 import os
 import pyfastaq
-from ariba import megares_zip_parser
+from ariba import common, megares_zip_parser
 
 modules_dir = os.path.dirname(os.path.abspath(megares_zip_parser.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
@@ -28,7 +26,7 @@ class TestMegaresZipParser(unittest.TestCase):
         for filename in expected.values():
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, filename)))
 
-        shutil.rmtree(tmp_dir)
+        common.rmtree(tmp_dir)
 
 
     def test_extract_files_one_missing(self):

--- a/ariba/tests/mic_plotter_test.py
+++ b/ariba/tests/mic_plotter_test.py
@@ -1,5 +1,4 @@
 import unittest
-import copy
 import filecmp
 import os
 from ariba import mic_plotter
@@ -109,7 +108,7 @@ class TestMicPlotter(unittest.TestCase):
                 'cluster3': {'assembled': 'no', 'match': 'no', 'ref_seq': 'NA', 'pct_id': 'NA', 'known_var': 'no', 'novel_var': 'no', 'A42T': 'no', 'A44T.%': 'NA'},
                 'cluster4': {'assembled': 'yes', 'match': 'yes', 'ref_seq': 'ref4', 'pct_id': 100.0, 'known_var': 'yes', 'novel_var': 'no', 'group4.A44T': 'no', 'group4.A44T.%': 'NA'},
             },
-        } 
+        }
 
         expected_top_plot_data = {
             'antibio1': {
@@ -262,7 +261,7 @@ class TestMicPlotter(unittest.TestCase):
         '''test _top_plot_y_ticks'''
         # FIXME
         pass
-        
+
 
     def test_top_plot_scatter_counts(self):
         '''test _top_plot_scatter_counts'''

--- a/ariba/tests/pubmlst_getter_test.py
+++ b/ariba/tests/pubmlst_getter_test.py
@@ -1,9 +1,6 @@
 import unittest
-import sys
 import os
-import pyfastaq
 import filecmp
-import pymummer
 from ariba import pubmlst_getter
 
 modules_dir = os.path.dirname(os.path.abspath(pubmlst_getter.__file__))

--- a/ariba/tests/pubmlst_ref_preparer_test.py
+++ b/ariba/tests/pubmlst_ref_preparer_test.py
@@ -2,9 +2,8 @@ import unittest
 import os
 import copy
 import filecmp
-import shutil
 import pyfastaq
-from ariba import mlst_profile, pubmlst_ref_preparer
+from ariba import common, mlst_profile, pubmlst_ref_preparer
 
 modules_dir = os.path.dirname(os.path.abspath(pubmlst_ref_preparer.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
@@ -39,7 +38,7 @@ class TestPubmlstRefPreparer(unittest.TestCase):
         r_prep._load_fasta_files_and_write_clusters_file(indir)
         expected_cluster_tsv = os.path.join(data_dir, 'pubmlst_ref_prepare.test_load_fa_and_clusters.expect.tsv')
         self.assertTrue(filecmp.cmp(expected_cluster_tsv, r_prep.clusters_file, shallow=False))
-        shutil.rmtree(outdir)
+        common.rmtree(outdir)
 
         expected_fasta_files = [os.path.join(indir, x) for x in ['gene1.tfa', 'gene2.tfa']]
         self.assertEqual(expected_fasta_files, r_prep.fasta_files)

--- a/ariba/tests/ref_preparer_test.py
+++ b/ariba/tests/ref_preparer_test.py
@@ -1,8 +1,7 @@
 import unittest
 import os
-import shutil
 import filecmp
-from ariba import external_progs, ref_preparer
+from ariba import common, external_progs, ref_preparer
 
 modules_dir = os.path.dirname(os.path.abspath(ref_preparer.__file__))
 data_dir = os.path.join(modules_dir, 'tests', 'data')
@@ -132,7 +131,7 @@ class TestRefPreparer(unittest.TestCase):
             got = os.path.join(tmp_out, filename)
             self.assertTrue(filecmp.cmp(expected, got, shallow=False))
 
-        shutil.rmtree(tmp_out)
+        common.rmtree(tmp_out)
 
 
     def test_run_all_noncoding(self):
@@ -167,7 +166,7 @@ class TestRefPreparer(unittest.TestCase):
             got = os.path.join(tmp_out, filename)
             self.assertTrue(filecmp.cmp(expected, got, shallow=False))
 
-        shutil.rmtree(tmp_out)
+        common.rmtree(tmp_out)
 
 
 

--- a/ariba/tests/ref_seq_chooser_test.py
+++ b/ariba/tests/ref_seq_chooser_test.py
@@ -1,7 +1,6 @@
 import unittest
 import sys
 import os
-import pyfastaq
 import filecmp
 import pymummer
 from ariba import ref_seq_chooser

--- a/ariba/tests/summary_cluster_variant_test.py
+++ b/ariba/tests/summary_cluster_variant_test.py
@@ -1,5 +1,4 @@
 import unittest
-import os
 from ariba import summary_cluster, summary_cluster_variant
 
 


### PR DESCRIPTION
Replaces every occurrence of `shutil.rmtree` with a call to `rm -rf`. Hoping this will fix #203 and #205.