### PR TITLE
Update python min version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please read the [ARIBA wiki page][ARIBA wiki] for full usage instructions.
 If you encounter an issue when installing ARIBA please contact your local system administrator. If you encounter a bug please log it [here](https://github.com/sanger-pathogens/ariba/issues) or email us at ariba-help@sanger.ac.uk.
 
 ### Required dependencies
-  * [Python3][python] version >= 3.3.2
+  * [Python3][python] version >= 3.4.0
   * [Bowtie2][bowtie2] version >= 2.1.0
   * [CD-HIT][cdhit] version >= 4.6
   * [MUMmer][mummer] version >= 3.23
@@ -73,6 +73,7 @@ are not already installed:
   * pyfastaq >= 3.12.0
   * pysam >= 0.9.1
   * pymummer >= 0.10.1
+  * biopython
 
 ### Using pip3
 Install ARIBA using pip:


### PR DESCRIPTION
Addition of ariba/tb.py itroduced biopython as dependency. Need python >= 3.4 for this.