### PR TITLE
Handle megares 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 addons:
   apt:
     packages:
-    - cython
+    - cython3
     - zlib1g-dev
     - libblas-dev
     - liblapack-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 addons:
   apt:
     packages:
-    - python3-pysam
     - zlib1g-dev
     - libblas-dev
     - liblapack-dev
@@ -12,6 +11,7 @@ python:
 - '3.6'
 sudo: false
 install:
+- pip install --upgrade pip
 - source ./install_dependencies.sh
 before_script:
 - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 addons:
   apt:
     packages:
-    - cython3
+    - python3-pysam
     - zlib1g-dev
     - libblas-dev
     - liblapack-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 - '3.6'
 sudo: false
 install:
-- pip install --upgrade pip
+- pip install pysam
 - source ./install_dependencies.sh
 before_script:
 - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 addons:
   apt:
     packages:
+    - cython
     - zlib1g-dev
     - libblas-dev
     - liblapack-dev


### PR DESCRIPTION
Fixes issues #287 and #294.

megares changed the filenames and format of their download between versions 1.0.1 and 2.0.0. This PR fixes `ariba getref` so that it works for all available versions (<=2.0.0) of megares at the time of writing.