### PR TITLE
fix SPAdes version capture

### DIFF
--- a/ariba/external_progs.py
+++ b/ariba/external_progs.py
@@ -33,7 +33,7 @@ prog_to_version_cmd = {
     'bowtie2': ('--version', re.compile('.*bowtie2.*version (.*)$')),
     'cdhit': ('', re.compile('CD-HIT version ([0-9\.]+) \(')),
     'nucmer': ('--version', re.compile('([0-9]+\.[0-9\.]+.*$)')),
-    'spades': ('--version', re.compile('SPAdes\s+v([0-9\.]+)'))
+    'spades': ('--version', re.compile('SPAdes.*v([0-9\.]+)'))
 }
 
 


### PR DESCRIPTION
This is related to https://github.com/sanger-pathogens/ariba/issues/314

At some point SPAdes changed their `--version` output, causing the warning message from `ariba --version`

```
spades.py --version
SPAdes genome assembler v3.15.2
```

```
ariba version
WARNING: I tried to get the version of spades with: "/home/robert_petit/miniconda3/envs/ariba/bin/spades.py --version" and the output didn't match this regular expression: "SPAdes\s+v([0-9\.]+)"
ARIBA version: 2.14.6

External dependencies:
bowtie2 2.2.5   /home/robert_petit/miniconda3/envs/ariba/bin/bowtie2
cdhit   4.8.1   /home/robert_petit/miniconda3/envs/ariba/bin/cd-hit-est
nucmer  3.1     /home/robert_petit/miniconda3/envs/ariba/bin/nucmer
spades  ERROR   /home/robert_petit/miniconda3/envs/ariba/bin/spades.py

External dependencies OK: True

Python version:
3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05)
[GCC 9.3.0]

Python packages:
ariba   2.14.6  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/ariba/__init__.py
bs4     4.9.3   /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/bs4/__init__.py
dendropy        4.5.2   /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/dendropy/__init__.py
pyfastaq        3.17.0  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pyfastaq/__init__.py
pymummer        0.10.3  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pymummer/__init__.py
pysam   0.16.0.1        /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pysam/__init__.py

Python packages OK: True

Everything looks OK: True
```

# With fix to regex
```
ariba version
ARIBA version: 2.14.6

External dependencies:
bowtie2 2.2.5   /home/robert_petit/miniconda3/envs/ariba/bin/bowtie2
cdhit   4.8.1   /home/robert_petit/miniconda3/envs/ariba/bin/cd-hit-est
nucmer  3.1     /home/robert_petit/miniconda3/envs/ariba/bin/nucmer
spades  3.15.2  /home/robert_petit/miniconda3/envs/ariba/bin/spades.py

External dependencies OK: True

Python version:
3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05)
[GCC 9.3.0]

Python packages:
ariba   2.14.6  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/ariba/__init__.py
bs4     4.9.3   /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/bs4/__init__.py
dendropy        4.5.2   /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/dendropy/__init__.py
pyfastaq        3.17.0  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pyfastaq/__init__.py
pymummer        0.10.3  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pymummer/__init__.py
pysam   0.16.0.1        /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pysam/__init__.py

Python packages OK: True

Everything looks OK: True
```

# With previous version of SPAdes
```
spades.py --version
SPAdes v3.13.0
```
````
ARIBA version: 2.14.6

External dependencies:
bowtie2 2.2.5   /home/robert_petit/miniconda3/envs/ariba/bin/bowtie2
cdhit   4.8.1   /home/robert_petit/miniconda3/envs/ariba/bin/cd-hit-est
nucmer  3.1     /home/robert_petit/miniconda3/envs/ariba/bin/nucmer
spades  3.13.0  /home/robert_petit/miniconda3/envs/ariba/bin/spades.py

External dependencies OK: True

Python version:
3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05)
[GCC 9.3.0]

Python packages:
ariba   2.14.6  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/ariba/__init__.py
bs4     4.9.3   /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/bs4/__init__.py
dendropy        4.5.2   /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/dendropy/__init__.py
pyfastaq        3.17.0  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pyfastaq/__init__.py
pymummer        0.10.3  /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pymummer/__init__.py
pysam   0.16.0.1        /home/robert_petit/miniconda3/envs/ariba/lib/python3.8/site-packages/pysam/__init__.py

Python packages OK: True

Everything looks OK: True
```