### PR TITLE
Switch from nosetest -> pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=env

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,7 @@ setup(
     author='Martin Hunt',
     url='https://github.com/sanger-pathogens/ariba',
     scripts=glob.glob('scripts/*'),
-    test_suite='nose.collector',
-    tests_require=['nose >= 1.3'],
+    tests_require=['pytest'],
     install_requires=[
         'BeautifulSoup4 >= 4.1.0',
         'biopython < 1.78',


### PR DESCRIPTION
Hi,

nose has been deprecated long back, and has not received an update in years, it's official page says so as well, see here
It is advised to switch to pytest/unittest2/nose2.

This is an attempt to switch to pytest. Please consider merging.

=============================================================================================

CC: @puethe @rpetit3 