### PR TITLE
Ignore comments column and drop Bio.Alphabet

### DIFF
--- a/ariba/mlst_profile.py
+++ b/ariba/mlst_profile.py
@@ -8,7 +8,7 @@ class MlstProfile:
     def __init__(self, infile, duplicate_warnings=True):
         self.infile = infile
         self.duplicate_warnings = duplicate_warnings
-        self.columns_to_ignore = ['clonal_complex', 'CC', 'Lineage', 'mlst_clade', 'species']
+        self.columns_to_ignore = ['clonal_complex', 'CC', 'Lineage', 'mlst_clade', 'species', 'comments']
 
         if not os.path.exists(self.infile):
             raise Error('Error! Input file "' + self.infile + '" not found.')

--- a/ariba/ref_genes_getter.py
+++ b/ariba/ref_genes_getter.py
@@ -617,7 +617,6 @@ class RefGenesGetter:
                                                webenv=webenv, query_key=query_key,
                                                idtype="acc")
             #pull out the records as fasta from the genbank
-            from Bio.Alphabet import generic_dna
             from Bio import SeqIO
             from Bio.Seq import Seq
             from Bio.SeqRecord import SeqRecord
@@ -645,7 +644,7 @@ class RefGenesGetter:
                                 except KeyError:
                                     print(f"gb_feature.qualifer not found", file=sys.stderr)
                             accession = gb_record.id
-                            seq_out = Seq(str(gb_feature.extract(gb_record.seq)), generic_dna)
+                            seq_out = Seq(str(gb_feature.extract(gb_record.seq)))
                             record_new.append(SeqRecord(seq_out,
                                          id=f"{id[0]}.{accession}",
                                          description=""))


### PR DESCRIPTION
The MLST profile for *Candida glabrata* has a column named `comments` which is not in the ignore list. This PR adds it to the ignore list, as well as drops `Bio.Alphabet` which has been removed in latest Biopython versions.

https://pubmlst.org/bigsdb?db=pubmlst_cglabrata_seqdef&page=downloadProfiles&scheme_id=1
```
ST	FKS	LEU2	NMT1	TRP1	UGP1	URA3	comments
1	7	1	1	6	4	4	
2	1	2	2	1	1	1	
3	5	7	8	7	3	6	
4	7	3	9	8	1	5	
5	5	7	8	1	3	6	
6	2	5	7	5	1	2	
7	3	4	4	3	3	4	
8	1	2	2	1	2	1	
```