### PR TITLE
Enhancements in vfdb_parser.py for VFDB full dataset support 

### DIFF
--- a/ariba/vfdb_parser.py
+++ b/ariba/vfdb_parser.py
@@ -3,7 +3,7 @@ import pyfastaq
 
 class Error (Exception): pass
 
-name_regex = re.compile(r'^(?P<vfdb_id>V\S+\)) \((?P<name>\S+)\) (?P<description>.*\]) \[(?P<genus_etc>.*)\]$')
+name_regex = re.compile(r'^(?P<vfdb_id>V\S+) \((?P<name>.*?)\) (?P<description>.*\]) \[(?P<genus_etc>.*)\]$')
 
 class VfdbParser:
     def __init__(self, infile, outprefix):

--- a/ariba/vfdb_parser.py
+++ b/ariba/vfdb_parser.py
@@ -92,14 +92,24 @@ class VfdbParser:
         fa_out = pyfastaq.utils.open_file_write(self.outprefix + '.fa')
         tsv_out = pyfastaq.utils.open_file_write(self.outprefix + '.tsv')
 
-        vfid_dict = VfdbParser._load_VFs_xls_metadata(self.outprefix)
+        vfid_dict = self._load_VFs_xls_metadata(self.outprefix)
+        seqid_list = []
         
         for seq in file_reader:
             original_id = seq.id
             seq.id, description = self._fa_header_to_name_and_metadata(seq.id)
-            vf_metadata = VfdbParser._vfid_to_metadata(vfid_dict, description)
+            vf_metadata = self._vfid_to_metadata(vfid_dict, description)
             if description == '.':
                 seq.id = original_id.split()[0]
+            
+            # remove sequences with duplicate ids
+            seqid = seq.id.split()[0]
+    
+            if seqid in seqid_list:
+                print('Duplicate entry ' + seqid + ' removed from downloaded dataset.')
+                continue
+            seqid_list.append(seqid)
+            
             print(seq.id, '1', '0', '.', '.', description + ': '+ vf_metadata + ' Original name: ' + original_id, sep='\t', file=tsv_out)
             print(seq, file=fa_out)
 

--- a/ariba/vfdb_parser.py
+++ b/ariba/vfdb_parser.py
@@ -1,9 +1,15 @@
 import re
 import pyfastaq
+import gzip
+import pandas as pd
+import subprocess
+import os
+from ariba import common
 
 class Error (Exception): pass
 
 name_regex = re.compile(r'^(?P<vfdb_id>V\S+) \((?P<name>.*?)\) (?P<description>.*\]) \[(?P<genus_etc>.*)\]$')
+desc_regex = re.compile(r'^[^[]*\[.*\((?P<vf_id>V\S+)\) .*\]$')
 
 class VfdbParser:
     def __init__(self, infile, outprefix):
@@ -27,20 +33,74 @@ class VfdbParser:
             return fa_header, '.'
         else:
             vfdb_id, name, description, genus_etc = name_data
-            return name + '.' + vfdb_id + '.' + genus_etc.replace(' ', '_'), description
+            vf_id = VfdbParser._name_piece_description_to_vfid(description)
+            return name.replace(' ', '_') + '.' + vfdb_id + '.' + genus_etc.replace(' ', '_'), vf_id
 
+        
+    @classmethod
+    def _name_piece_description_to_vfid(cls, description):
+        n = desc_regex.search(description)
+        if n is None:
+            return description
+        else:
+            return n.group('vf_id')
+
+        
+    @classmethod
+    def _load_VFs_xls_metadata(cls, outprefix):
+        filename = 'VFs.xls.gz'
+        # get tmpdir as defined in ref_genes_getter.py
+        outprefix = os.path.abspath(outprefix)
+        tmpdir = outprefix + '.tmp.download'
+        
+        if not os.path.exists(tmpdir):
+            try:
+                os.mkdir(tmpdir)
+            except:
+                raise Error('Error mkdir ' + tmpdir)
+            
+        zipfile = os.path.join(tmpdir, filename)
+        common.download_file('http://www.mgc.ac.cn/VFs/Down/' + filename, zipfile)
+        
+        retcode = subprocess.call('gunzip -t ' + zipfile, shell=True)
+        if retcode != 0:
+            raise Error("Error opening for reading gzipped file '" + filename + "'")
+
+        with gzip.open(zipfile, 'r') as handle:
+            vfdb_meta_df = pd.read_excel(handle, header = 1, usecols = ['VFID', 'VF_Name', 'VFcategory', 'Function', 'Mechanism'], keep_default_na = False)
+        vfdb_meta_df['description'] = vfdb_meta_df['VF_Name']+' ('+vfdb_meta_df['VFcategory']+'). '+vfdb_meta_df['Function']+' '+vfdb_meta_df['Mechanism']
+        vfid_dict = dict(zip(vfdb_meta_df['VFID'], vfdb_meta_df['description']))
+        del(vfdb_meta_df)
+
+        return vfid_dict
+
+    
+    @classmethod
+    def _vfid_to_metadata(cls, vfid_dict, vf_id):
+        if vf_id is not None:
+            vf_metadata = vfid_dict.get(vf_id)
+            if vf_metadata is None:
+                return ''
+            else:
+                return vf_metadata
+        else:
+            return ''       
+        
 
     def run(self):
         file_reader = pyfastaq.sequences.file_reader(self.infile)
         fa_out = pyfastaq.utils.open_file_write(self.outprefix + '.fa')
         tsv_out = pyfastaq.utils.open_file_write(self.outprefix + '.tsv')
 
+        vfid_dict = VfdbParser._load_VFs_xls_metadata(self.outprefix)
+        
         for seq in file_reader:
             original_id = seq.id
             seq.id, description = self._fa_header_to_name_and_metadata(seq.id)
+            vf_metadata = VfdbParser._vfid_to_metadata(vfid_dict, description)
             if description == '.':
                 seq.id = original_id.split()[0]
-            print(seq.id, '1', '0', '.', '.', 'Original name: ' + original_id, sep='\t', file=tsv_out)
+            print(seq.id, '1', '0', '.', '.', description + ': '+ vf_metadata + ' Original name: ' + original_id, sep='\t', file=tsv_out)
             print(seq, file=fa_out)
 
         pyfastaq.utils.close(fa_out)


### PR DESCRIPTION
Currently, when using the `getref vfbd_full (...)` command downloading the full VFDB dataset, it is not possible to proceed with `ariba preparef (...)` using the resulting reference data without manual changes to both the .fa and the .tsv files. This is, because the reference data set contains several pitfalls not adressed yet:

- Duplicate sequence IDs raising errors in `ariba prepareref`.
- Sequences with stop codons, which are filtered out. (The metadata.tsv file created by vfdb_parser is currently declaring every sequence from the dataset as gene).
- Gene symbols including brackets or blank spaces, so the intended naming is not working for every sequence complicating the creation of meaningful cluster names.

The modifications proposed here adress all shortcomings mentioned above.
Furthermore, the xls-derived metadata from VFDB explaining function and mechanism of a respective virulence gene (VFs.xls.gz, see _VFs description file_ on [VFDB download page](http://www.mgc.ac.cn/VFs/download.htm)) are included into the metadata.tsv derived from vfdb_parser to allow a more comprehensive view of the ariba variant calling results for working with VFDB. 

Thank you for considering to merge for a future release.